### PR TITLE
Fix installation of versions on ubuntu

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -230,8 +230,11 @@ execute_with_version() {
   test -z $1 && abort "version required"
   local version=${1#v}
   local bin=$VERSIONS_DIR/$version/bin/node
+
+  shift # remove version
+
   if test -f $bin; then
-    $bin ${@:2}
+    $bin $@
   else 
     abort "$1 is not installed"
   fi
@@ -284,10 +287,10 @@ else
       -h|--help|help) display_help ;;
       --latest) display_latest_version $2; exit ;;
       bin|which) display_bin_path_for_version $2; exit ;;
-      as|use) execute_with_version ${@:2}; exit ;;
-      rm|-) remove_version ${@:2}; exit ;;
+      as|use) shift; execute_with_version $@; exit ;;
+      rm|-) remove_version $2; exit ;;
       latest) install_node `n --latest`; exit ;;
-      ls|list) list_versions ${@:2}; exit ;;
+      ls|list) list_versions $2; exit ;;
       *) install_node $@; exit ;;
     esac
     shift


### PR DESCRIPTION
This fixes the installation of versions under Ubuntu as mention in #14 and #15. The problem is that the `&>` is interpreted wrong and forces the operation to go to the background and therefore is the current working dir not the expected `$N_PREFIX/n`. Instead the `cwd` is the directory from where the command was executed.

Also it is executing the dependent commands before the download and unpacking is finished, which leads to further problems.
