### PR TITLE
fix node-waf

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -139,7 +139,7 @@ install_node() {
       && cp -fr $dir/include/node $PREFIX/include \
       && cp -f $dir/bin/node $PREFIX/bin/node \
       && cp -f $dir/bin/node-waf $PREFIX/bin/node-waf \
-      && cp -fr $dir/lib/node/* $PREFIX/lib/node
+      && cp -fr $dir/lib/node/* $PREFIX/lib/node/.
   # install
   else
     local tarball="node-v$version.tar.gz"


### PR DESCRIPTION
ran into npm-errors when i tried to install bcrypt

```
> bcrypt@0.4.0 install ~/node_modules/bcrypt
> make build

rm -f bcrypt_lib.node
rm -Rf build
node-waf configure
Traceback (most recent call last):
  File "/usr/local/bin/node-waf", line 14, in <module>
    import Scripting
ImportError: No module named Scripting
make: *** [configure] Error 1
```

it turned out that `$dir/lib/node/wafadmin` was copied directly into 
`$PREFIX/lib/node`.
