### PR TITLE
Convert 'echo' to 'echo -e' to enable color escape codes

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -11,7 +11,7 @@ VERSIONS_DIR=$N_PREFIX/n/versions
 #
 
 log() {
-  echo "\033[90m...\033[0m $@"
+  echo -e "\033[90m...\033[0m $@"
 }
 
 #
@@ -19,7 +19,7 @@ log() {
 #
 
 abort() {
-  echo "\033[31mError: $@\033[0m" && exit 1
+  echo -e "\033[31mError: $@\033[0m" && exit 1
 }
 
 # setup
@@ -112,9 +112,9 @@ display_versions() {
     local version=${dir##*/}
     local config=`test -f $dir/.config && cat $dir/.config`
     if test "$version" = "$active"; then
-      echo "  \033[32mο\033[0m $version \033[90m$config\033[0m"
+      echo -e "  \033[32mο\033[0m $version \033[90m$config\033[0m"
     else
-      echo "    $version \033[90m$config\033[0m"
+      echo -e "    $version \033[90m$config\033[0m"
     fi
   done
 }
@@ -160,7 +160,7 @@ install_node() {
     # see if things are alright
     if test $? -gt 0; then
       rm $tarball
-      echo "\033[31mError: installation failed\033[0m"
+      echo -e "\033[31mError: installation failed\033[0m"
       echo "  node version $version does not exist,"
       echo "  n failed to fetch the tarball,"
       echo "  or tar failed. Try a different"
@@ -290,10 +290,10 @@ list_versions() {
 
   for v in $versions; do
     if test "$active" = "$v"; then
-      echo "  \033[32mο\033[0m $v \033[0m"
+      echo -e "  \033[32mο\033[0m $v \033[0m"
     else
       if test -d $VERSIONS_DIR/$v; then
-        echo "  * $v \033[0m"
+        echo -e "  * $v \033[0m"
       else
         echo "    $v"
       fi


### PR DESCRIPTION
On my machine, using this tool looks like the following:

```
[user@machine ~]$ n
  \033[32mο\033[0m 0.6.5 \033[90m\033[0m
```

To make the color escape codes work properly, just had to add the '-e' flag to the echoes that use them.
