### PR TITLE
Fix log colors on linux

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -11,7 +11,7 @@ VERSIONS_DIR=$N_PREFIX/n/versions
 #
 
 log() {
-  printf "\e[90m...\e[0m $@\n"
+  printf "\033[90m...\033[0m $@\n"
 }
 
 #
@@ -19,7 +19,7 @@ log() {
 #
 
 abort() {
-  printf "\e[31mError: $@\e[0m\n" && exit 1
+  printf "\033[31mError: $@\033[0m\n" && exit 1
 }
 
 # setup
@@ -114,9 +114,9 @@ display_versions() {
     local version=${dir##*/}
     local config=`test -f $dir/.config && cat $dir/.config`
     if test "$version" = "$active"; then
-      printf "  \e[32mο\e[0m $version \e[90m$config\e[0m\n"
+      printf "  \033[32mο\033[0m $version \033[90m$config\033[0m\n"
     else
-      printf "    $version \e[90m$config\e[0m\n"
+      printf "    $version \033[90m$config\033[0m\n"
     fi
   done
 }
@@ -312,10 +312,10 @@ list_versions() {
 
   for v in $versions; do
     if test "$active" = "$v"; then
-      printf "  \e[32mο\e[0m $v \e[0m\n"
+      printf "  \033[32mο\033[0m $v \033[0m\n"
     else
       if test -d $VERSIONS_DIR/$v; then
-        printf "  * $v \e[0m\n"
+        printf "  * $v \033[0m\n"
       else
         printf "    $v\n"
       fi


### PR DESCRIPTION
Changed the new \e control character back to \033 so it works on Linux.  Tested on both Ubuntu 11.10 and Mac OSX 10.6.8 (Snow Leopard)
