### PR TITLE
Fix for #48 ImportError: No module named Scripting 

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -142,7 +142,8 @@ install_node() {
       && cp -fr $dir/include/node $N_PREFIX/include \
       && cp -f $dir/bin/node $N_PREFIX/bin/node \
       && cp -f $dir/bin/node-waf $N_PREFIX/bin/node-waf \
-      && cp -fr $dir/lib/node/* $N_PREFIX/lib/node/ .
+      && cp -fr $dir/lib/node/* $N_PREFIX/lib/node/ . \
+      && ln -s $dir/wafadmin $N_PREFIX/lib/node/
   # install
   else
     local tarball="node-v$version.tar.gz"


### PR DESCRIPTION
Creating link for wafadmin folder in $N_PREFIX/lib/node/

See https://github.com/visionmedia/n/issues/48
