### PR TITLE
Explicitly require bash rather than sh

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Library version
 


### PR DESCRIPTION
I ran into a bug on a SmartOS vm. I get this error when trying to invoke `n` because apparently `local` is not defined in `sh` on SmartOS:

```
$n
/home/node/local/nodejs/bin/node
/home/node/local/bin/n[116]: local: not found [No such file or directory]
/home/node/local/bin/n[117]: local: not found [No such file or directory]
```

Here are the versions of each.

```
$ sh --version
  version         sh (AT&T Research) 93t+ 2010-03-05

$ bash --version
GNU bash, version 4.1.0(1)-release (i386-pc-solaris2.11)
Copyright (C) 2009 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

I changed the shell script header to require `bash` rather than the more ambiguous `sh`.
