### PR TITLE
preserve npm symlink

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -141,9 +141,9 @@ install_node() {
     # TODO: refactor, this is lame
     cd $dir \
       && mkdir -p $N_PREFIX/lib/node \
-      && cp -fr $dir/include/node $N_PREFIX/include \
-      && cp -f $dir/bin/* $N_PREFIX/bin \
-      && cp -fr $dir/lib/node/* $N_PREFIX/lib/node/ .
+      && cp -fR $dir/include/node $N_PREFIX/include \
+      && cp -fR $dir/bin/* $N_PREFIX/bin \
+      && cp -fR $dir/lib/node/* $N_PREFIX/lib/node/ .
   # install
   else
     local tarball="node-v$version.tar.gz"


### PR DESCRIPTION
OS X 10.6.8, for the cp command, the -R flag replaces -r and preserves symlinks by default. Added this to the cp command which copies the node, node-waf, npm etc binaries so that npm is copied to /usr/local/bin as a symlink. Otherwise npm quits working as soon as you do an n <version> switch, since it follows the npm symlink and copies the npm file directly to /usr/local/bin, where npm then fails to find ../lib/utils/log.js

On Ubuntu 10.04+, the -R and -r flags are synonymous.

Tested on Mac OS X 10.6.8 but not on Ubuntu (yet)...
