### PR TITLE
Use symlinks instead of copying files upon switch

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -138,12 +138,11 @@ install_node() {
   # activate
   local dir=$VERSIONS_DIR/$version
   if test -d $dir; then
-    # TODO: refactor, this is lame
-    cd $dir \
-      && mkdir -p $N_PREFIX/lib/node \
-      && cp -fR $dir/include/node $N_PREFIX/include \
-      && cp -fR $dir/bin/* $N_PREFIX/bin \
-      && cp -fR $dir/lib/node/* $N_PREFIX/lib/node/ .
+    # symlink everything, purge old copies or symlinks
+    for d in bin lib share include; do
+      rm -rf $N_PREFIX/$d
+      ln -s $dir/$d $N_PREFIX/$d
+    done
   # install
   else
     local tarball="node-v$version.tar.gz"


### PR DESCRIPTION
Backward incompatible change - any modules and executables
such as npm, coffee and even n itself are now different
for different node versions. 

This is probably a good thing anyway. At least you won't get something like 
"npm won't work with your node 0.8.11, install 0.6, please"
