### PR TITLE
uname lookup broken on ubuntu 12.04

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -215,7 +215,7 @@ is_ok() {
 
 tarball_url() {
   local version=$1
-  local uname=$(uname -a)
+  local uname="$(uname -a)"
   local arch=x86
   local os=
 


### PR DESCRIPTION
I escaped the lookup and works fine for me now. Tested other os and still worked.
