### PR TITLE
Use rsync instead of cp when activating versions

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -242,7 +242,7 @@ activate() {
   local dir=$VERSIONS_DIR/$version
   check_current_version
   echo $active > $VERSIONS_DIR/.prev
-  cp -fr $dir/* $N_PREFIX
+  rsync -K -a $dir/* $N_PREFIX
 }
 
 #


### PR DESCRIPTION
The cp command is not capable of handling symlinks properly. The rync command treats symlinked directories on receiver as regular directories.

This is a way of working around the issues cp reports when it encounters symlinks as reported in Issue #100.
