### PR TITLE
Only copy over node-specific sub-directories

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -242,7 +242,7 @@ activate() {
   local dir=$VERSIONS_DIR/$version
   check_current_version
   echo $active > $VERSIONS_DIR/.prev
-  cp -fr $dir/* $N_PREFIX
+  cp -fr $dir/bin $dir/lib $dir/share $N_PREFIX
 }
 
 #


### PR DESCRIPTION
Stops the clobbering of any existing `README.md`, `ChangeLog` or `LICENSE` files in the target dir

(this especially affects `brew`, which cannot update if `/usr/local/README.md` is modified - which it is by the default `n` installation)
