### PR TITLE
Add RPI support

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -228,6 +228,7 @@ tarball_url() {
 
   case "$uname" in
     *x86_64*) arch=x64 ;;
+    *armv6l*) arch=arm-pi ;;
   esac
 
   echo "http://nodejs.org/dist/v${version}/node-v${version}-${os}-${arch}.tar.gz"


### PR DESCRIPTION
Uses `arm-pi` tarball if arch is `armv6l`, fixes #108...
