### PR TITLE
Switch from which to command -v

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -33,10 +33,10 @@ abort() {
 GET=
 
 # wget support (Added --no-check-certificate for Github downloads)
-which wget > /dev/null && GET="wget --no-check-certificate -q -O-"
+command -v wget > /dev/null && GET="wget --no-check-certificate -q -O-"
 
 # curl support
-which curl > /dev/null && GET="curl -# -L"
+command -v curl > /dev/null && GET="curl -# -L"
 
 # Ensure we have curl or wget
 


### PR DESCRIPTION
So that you don't have to redirect sdterr to /dev/null to not get output like the following:

```
$ n 0.8.25
which: no wget in (/usr/local/bin:/usr/bin:/bin:/home/eivind/bin:/usr/bin/core_perl:/home/eivind/.gem/bin:/home/eivind/node_modules/.bin)
```
