### PR TITLE
Use -R when activating. Fixes #118

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -243,7 +243,7 @@ activate() {
   local dir=$VERSIONS_DIR/$version
   check_current_version
   echo $active > $VERSIONS_DIR/.prev
-  cp -fr $dir/* $N_PREFIX
+  cp -fR $dir/* $N_PREFIX
 }
 
 #


### PR DESCRIPTION
For some reason the old -r flag isn't properly copying the files across, using -R seems to fix this.
