### PR TITLE
Optimize activate

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -240,10 +240,12 @@ tarball_url() {
 
 activate() {
   local version=$1
-  local dir=$VERSIONS_DIR/$version
   check_current_version
-  echo $active > $VERSIONS_DIR/.prev
-  cp -fR $dir/* $N_PREFIX
+  if [ "$version" != "$active" ]; then
+    local dir=$VERSIONS_DIR/$version
+    echo $active > $VERSIONS_DIR/.prev
+    cp -fR $dir/* $N_PREFIX
+  fi
 }
 
 #


### PR DESCRIPTION
Currently activate() copies activated version even if it is already in use:

```
$ for((i=0; i < 3; i++))
> do
> sudo n $(node --version|cut -c2-)
> ls --full-time $(which node)
> done
/usr/local/bin/node
-rwxr-xr-x 1 root root 9018962 2013-07-07 14:38:38.651703976 +0000 /usr/local/bin/node
/usr/local/bin/node
-rwxr-xr-x 1 root root 9018962 2013-07-07 14:38:41.321037976 +0000 /usr/local/bin/node
/usr/local/bin/node
-rwxr-xr-x 1 root root 9018962 2013-07-07 14:38:42.837795976 +0000 /usr/local/bin/node
```

With fix:

```
$ for((i=0; i < 3; i++))
> do
> sudo n $(node --version|cut -c2-)
> ls --full-time $(which node)
> done
/usr/local/bin/node
-rwxr-xr-x 1 root root 9018962 2013-07-07 14:38:42.837795976 +0000 /usr/local/bin/node
/usr/local/bin/node
-rwxr-xr-x 1 root root 9018962 2013-07-07 14:38:42.837795976 +0000 /usr/local/bin/node
/usr/local/bin/node
-rwxr-xr-x 1 root root 9018962 2013-07-07 14:38:42.837795976 +0000 /usr/local/bin/node
```
