### PR TITLE
n prev fix

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -255,6 +255,7 @@ activate() {
 activate_previous() {
   test -f $VERSIONS_DIR/.prev || abort "no previous versions activated"
   local prev=$(cat $VERSIONS_DIR/.prev)
+  test -d $VERSIONS_DIR/$prev || abort "previous version $prev not installed"
   activate $prev
   echo
   log activate $prev


### PR DESCRIPTION
`n prev` fails if you have uninstalled the previous version

If you call n prev and the previous version was uninstalled, the activate_previous function display a success, but it's false

This fix abort with an error message:

``` bash
$ n prev

  Error: previous version 0.10.12 not installed

```
