### PR TITLE
abort gracefully if no installed version

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -395,6 +395,7 @@ display_remote_versions() {
 # Handle arguments
 
 if test $# -eq 0; then
+  test "$(ls -l $VERSIONS_DIR | grep ^d)" || abort "no installed version"
   display_versions
 else
   while test $# -ne 0; do


### PR DESCRIPTION
When you use n for the first time or if you have removed all the versions under `/usr/local/n/versions` it shows a strange empty message:

``` bash


    * 

```

This fix just check if there is at least one directory inside `$VERSIONS_DIR`
If no, abort gracefully with the error:

``` bash
$ n

  Error: no installed version

```
