### PR TITLE
resolve version with one dot

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -267,6 +267,20 @@ activate_previous() {
 
 install_node() {
   local version=${1#v}
+
+  local dots=`echo $version | sed 's/[^.]*//g'`
+  if test ${#dots} -eq 1; then
+    version=`$GET 2> /dev/null http://nodejs.org/dist/ \
+    | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' \
+    | egrep -v '^0\.[0-7]\.' \
+    | egrep -v '^0\.8\.[0-5]$' \
+    | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
+    | egrep ^$version \
+    | tail -n1`
+    
+    test $version || abort "invalid version ${1#v}"
+  fi
+  
   local config=$@
   local dir=$VERSIONS_DIR/$version
   local url=$(tarball_url $version)


### PR DESCRIPTION
This enhancement allow to use single dot version like `0.8` or `0.10`

If the script detect it is a single dot version, it will resolve it to find the higher version available, so here  `0.8.25` and `0.10.12`

It use the same logic as `display_remote_versions`, so it's 0.8.6 minimum

It allows to quickly switch/install to the latest version of a "branch"
