### PR TITLE
only refresh listing if needed

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -177,12 +177,18 @@ display_versions() {
     read -s -n 3 c
     case "$c" in
       $UP)
-        clear
-        display_versions_with_selected $(prev_version_installed)
+        local prev=`prev_version_installed`
+        if test $prev != $selected; then
+          clear
+          display_versions_with_selected $prev
+        fi
         ;;
       $DOWN)
-        clear
-        display_versions_with_selected $(next_version_installed)
+        local next=`next_version_installed`
+        if test $next != $selected; then
+          clear
+          display_versions_with_selected $next
+        fi
         ;;
       *)
         clear


### PR DESCRIPTION
If you are at the top of the interactive listing and press the `$UP` key, it currently refresh the terminal: clear then compute `display_versions_with_selected` but it's not needed

Same for the `$DOWN` key at the bottom

This simple fix prevents some unnecessary refresh and calculations
