### PR TITLE
interactive listing sort fixed

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -133,6 +133,16 @@ check_current_version() {
   fi
 }
 
+# 
+# Display sorted versions directories paths
+# 
+
+versions_paths() {
+  ls -d $VERSIONS_DIR/* \
+    | egrep "/[0-9]+\.[0-9]+\.[0-9]+$" \
+    | sort -k 1,1n -k 2,2n -k 3,3n -t .
+}
+
 #
 # Display installed versions with <selected>.
 #
@@ -140,7 +150,7 @@ check_current_version() {
 display_versions_with_selected() {
   selected=$1
   echo
-  for dir in $VERSIONS_DIR/*; do
+  for dir in `versions_paths`; do
     local version=${dir##*/}
     local config=`test -f $dir/.config && cat $dir/.config`
     if test "$version" = "$selected"; then
@@ -157,7 +167,7 @@ display_versions_with_selected() {
 #
 
 list_versions_installed() {
-  for dir in $VERSIONS_DIR/*; do
+  for dir in `versions_paths`; do
     local version=${dir##*/}
     echo $version
   done
@@ -272,12 +282,12 @@ install_node() {
   local dots=`echo $version | sed 's/[^.]*//g'`
   if test ${#dots} -eq 1; then
     version=`$GET 2> /dev/null http://nodejs.org/dist/ \
-    | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' \
-    | egrep -v '^0\.[0-7]\.' \
-    | egrep -v '^0\.8\.[0-5]$' \
-    | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
-    | egrep ^$version \
-    | tail -n1`
+      | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' \
+      | egrep -v '^0\.[0-7]\.' \
+      | egrep -v '^0\.8\.[0-5]$' \
+      | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
+      | egrep ^$version \
+      | tail -n1`
     
     test $version || abort "invalid version ${1#v}"
   fi


### PR DESCRIPTION
When you list availabe remote version with `n ls`, the listing is correctly sorted:

```
    0.8.14
    0.8.15
    0.9.0
    0.9.1
    0.10.0
    0.10.1
```

But when you use the intertive listing to switch node version, the lising is currently like:

```
    0.10.0
    0.10.1
    0.8.14
    0.8.15
    0.9.0
    0.9.1
```

This fix correct this problem and also retrieve only valid node directory under `$VERSIONS_DIR/*` : only directories matching \d+.\d+.\d+ are returned

I'm very happy with this PR
