### PR TITLE
remove unused config

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,17 +28,6 @@ select, or ^C to cancel:
     ο 0.8.17
       0.9.6
 
-Pass some config flags to _./configure_:
-
-    $ n 0.2.6 --debug
-
-List installed binaries, config flags are shown:
-
-      0.2.3
-    ο 0.2.6 --debug
-      0.3.4
-      0.3.5
-
 Use or install the latest official release:
 
     $ n latest
@@ -55,40 +44,40 @@ Switch to the previous version you were using:
 
 Remove some versions:
 
-    $ n rm 0.2.4 v0.3.0
+    $ n rm 0.9.4 v0.10.0
 
 Instead of using `rm` we can simply use `-`:
 
-    $ n - 0.2.4
+    $ n - 0.9.4
 
 ### Binary Usage
 
 When running multiple versions of node, we can target
 them directly by asking `n` for the binary path:
 
-    $ n bin 0.3.3
-    /usr/local/n/versions/0.3.3/bin/node
+    $ n bin 0.9.4
+    /usr/local/n/versions/0.9.4/bin/node
 
 Or by using a specific version through `n`'s `use` sub-command:
 
-    $ n use 0.3.3 some.js
+    $ n use 0.9.4 some.js
 
 with flags:
 
-    $ n as 0.3.3 --debug some.js
+    $ n as 0.9.4 --debug some.js
 
 ## Usage
 
  Output from `n --help`:
 
-    Usage: n [options] [COMMAND] [config]
+    Usage: n [options] [COMMAND] [args]
 
     Commands:
 
       n                            Output versions installed
-      n latest [config ...]        Install or activate the latest node release
-      n stable [config ...]        Install or activate the latest stable node release
-      n <version> [config ...]     Install and/or use node <version>
+      n latest                     Install or activate the latest node release
+      n stable                     Install or activate the latest stable node release
+      n <version>                  Install node <version>
       n use <version> [args ...]   Execute node <version> with [args ...]
       n bin <version>              Output bin path for <version>
       n rm <version ...>           Remove the given version(s)

--- a/bin/n
+++ b/bin/n
@@ -1,14 +1,14 @@
 #!/usr/bin/env sh
 
-# Library version
+#
+# Setup.
+#
 
 VERSION="1.1.0"
 N_PREFIX=${N_PREFIX-/usr/local}
 VERSIONS_DIR=$N_PREFIX/n/versions
 UP=$'\033[A'
 DOWN=$'\033[B'
-
-# setup
 
 test -d $VERSIONS_DIR || mkdir -p $VERSIONS_DIR
 
@@ -28,17 +28,16 @@ abort() {
   printf "\n  \033[31mError: $@\033[0m\n\n" && exit 1
 }
 
-# curl / wget support
+#
+# Ensure we have curl or wget support.
+#
 
 GET=
 
 # wget support (Added --no-check-certificate for Github downloads)
 command -v wget > /dev/null && GET="wget --no-check-certificate -q -O-"
 
-# curl support
 command -v curl > /dev/null && GET="curl -# -L"
-
-# Ensure we have curl or wget
 
 test -z "$GET" && abort "curl or wget required"
 
@@ -47,16 +46,16 @@ test -z "$GET" && abort "curl or wget required"
 #
 
 display_help() {
-  cat <<-help
+  cat <<-EOF
 
-  Usage: n [options] [COMMAND] [config]
+  Usage: n [options] [COMMAND] [args]
 
   Commands:
 
     n                            Output versions installed
-    n latest [config ...]        Install or activate the latest node release
-    n stable [config ...]        Install or activate the latest stable node release
-    n <version> [config ...]     Install and/or use node <version>
+    n latest                     Install or activate the latest node release
+    n stable                     Install or activate the latest stable node release
+    n <version>                  Install node <version>
     n use <version> [args ...]   Execute node <version> with [args ...]
     n bin <version>              Output bin path for <version>
     n rm <version ...>           Remove the given version(s)
@@ -77,7 +76,7 @@ display_help() {
     list    ls
     -       rm
 
-help
+EOF
   exit 0
 }
 
@@ -134,7 +133,7 @@ check_current_version() {
 }
 
 #
-# Display sorted versions directories paths
+# Display sorted versions directories paths.
 #
 
 versions_paths() {
@@ -144,7 +143,7 @@ versions_paths() {
 }
 
 #
-# Display installed versions with <selected>.
+# Display installed versions with <selected>
 #
 
 display_versions_with_selected() {
@@ -152,11 +151,10 @@ display_versions_with_selected() {
   echo
   for dir in `versions_paths`; do
     local version=${dir##*/}
-    local config=`test -f $dir/.config && cat $dir/.config`
     if test "$version" = "$selected"; then
-      printf "  \033[36mο\033[0m $version \033[90m$config\033[0m\n"
+      printf "  \033[36mο\033[0m $version\033[0m\n"
     else
-      printf "    \033[90m$version $config\033[0m\n"
+      printf "    \033[90m$version\033[0m\n"
     fi
   done
   echo
@@ -174,8 +172,7 @@ list_versions_installed() {
 }
 
 #
-# Display current node --version
-# and others installed.
+# Display current node --version and others installed.
 #
 
 display_versions() {
@@ -220,7 +217,7 @@ is_ok() {
 }
 
 #
-# Determine tarball url for <version>.
+# Determine tarball url for <version>
 #
 
 tarball_url() {
@@ -251,7 +248,7 @@ tarball_url() {
 activate() {
   local version=$1
   check_current_version
-  if [ "$version" != "$active" ]; then
+  if test "$version" != "$active"; then
     local dir=$VERSIONS_DIR/$version
     echo $active > $VERSIONS_DIR/.prev
     cp -fR $dir/* $N_PREFIX
@@ -292,7 +289,6 @@ install_node() {
     test $version || abort "invalid version ${1#v}"
   fi
 
-  local config=$@
   local dir=$VERSIONS_DIR/$version
   local url=$(tarball_url $version)
 
@@ -302,7 +298,7 @@ install_node() {
   fi
 
   echo
-  log install $version
+  log install v$version
 
   is_ok $url || abort "invalid version $version"
 
@@ -347,8 +343,7 @@ display_bin_path_for_version() {
 }
 
 #
-# Execute the given <version> of node
-# with [args ...]
+# Execute the given <version> of node with [args ...]
 #
 
 execute_with_version() {
@@ -416,7 +411,9 @@ display_remote_versions() {
   echo
 }
 
-# Handle arguments
+#
+# Handle arguments.
+#
 
 if test $# -eq 0; then
   test "$(ls -l $VERSIONS_DIR | grep ^d)" || abort "no installed version"
@@ -435,7 +432,7 @@ else
       stable) install_node `n --stable`; exit ;;
       ls|list) display_remote_versions; exit ;;
       prev) activate_previous; exit ;;
-      *) install_node $@; exit ;;
+      *) install_node $1; exit ;;
     esac
     shift
   done


### PR DESCRIPTION
This fix removes the old and no more used `config` variable

I update the `n`code, the `n --help` and also the `Readme.md`

In the `Readme.md` I also change the demo version used like `0.2.6` because the minimum version is now `0.8.6`

The `display_help` function now use `<<-EOF` instead of `<<-help` to prevent a syntax highlightment bug here:
https://github.com/visionmedia/n/blob/master/bin/n#L50
