### PR TITLE
Added shell option to execute command with specific node version in PATH

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -57,6 +57,7 @@ display_help() {
     n stable                     Install or activate the latest stable node release
     n <version>                  Install node <version>
     n use <version> [args ...]   Execute node <version> with [args ...]
+    n shell <version> [exec args ...]   Execute node <version> with in a new shell or executable
     n bin <version>              Output bin path for <version>
     n rm <version ...>           Remove the given version(s)
     n prev                       Revert to the previously activated version
@@ -361,6 +362,29 @@ execute_with_version() {
 }
 
 #
+# Execute the given [exec args...] with the given <version> of node in its PATH
+#
+
+shell_with_version() {
+  test -z $1 && abort "version required"
+  local version=${1#v}
+  shift
+  local bindir=$VERSIONS_DIR/$version/bin
+  local exec
+  if test -n "$@"; then
+    exec=$@
+  else
+    exec="$SHELL"
+  fi
+
+  if test -f $bin; then
+    PATH=${bindir}:$PATH ${exec}
+  else
+    abort "$version is not installed"
+  fi
+}
+
+#
 # Display the latest node release version.
 #
 
@@ -427,6 +451,7 @@ else
       --stable) display_latest_stable_version; exit ;;
       bin|which) display_bin_path_for_version $2; exit ;;
       as|use) shift; execute_with_version $@; exit ;;
+      shell) shift; shell_with_version $@; exit ;;
       rm|-) shift; remove_versions $@; exit ;;
       latest) install_node `n --latest`; exit ;;
       stable) install_node `n --stable`; exit ;;


### PR DESCRIPTION
This allows people to use n to quickly start a shell with a specific version without altering their system:

    $ n shell 0.10.12
    $ node --version
    v0.10.12
    (ctrl+d)
    $ node --version
    v0.10.18

This also helps a lot with installing packages for a specific node version:

    $ n shell 0.10.12 npm install

It all works without write permissions to /usr/local/.