### PR TITLE
handle `Permission denied` for `mkdir`

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -304,6 +304,10 @@ install_node() {
 
   log mkdir $dir
   mkdir -p $dir
+  if [ $? -ne 0 ] ; then
+    abort "sudo required"
+  fi
+  
   cd $dir
 
   log fetch $url


### PR DESCRIPTION
I found if we have not an enough permission to run `mkdir`, the `n` process wouldn't quit, and continue to create some directories or files like `node`, `lib`, `README.md`.

That's not a good experience.
