### PR TITLE
Make n use bash

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 #
 # Setup.


### PR DESCRIPTION
On some systems, the default shell is not bash. This commit fixes issue #106
