### PR TITLE
Symbolic link installation option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+versions

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ PREFIX ?= /usr/local
 install: bin/n
 	cp $< $(PREFIX)/$<
 
+link: bin/n
+	ln -s $(CURDIR)/$< $(PREFIX)/$<
+
 uninstall:
 	rm -f $(PREFIX)/bin/n
 
-.PHONY: install uninstall
+.PHONY: install link uninstall


### PR DESCRIPTION
Makes `n` easier to update, specially if you use git.
Consider these commands:

```
cd /usr/local
git clone git@github.com:visionmedia/n.git
cd n
make link #to be merged
```

now every time `n` changes:

```
cd /usr/local/n
git pull
```
