### PR TITLE
add support for repo mirrors via N_MIRROR env variable

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -392,7 +392,6 @@ display_latest_stable_version() {
 #
 
 display_remote_versions() {
-  echo "displaying remote versions"
   check_current_version
   local versions=""
   versions=`$GET 2> /dev/null $N_MIRROR \


### PR DESCRIPTION
Usage:

```
export N_MIRROR="http://<hostname>[:<port>][/<filepath>/]"
```

Tested on Ubuntu 14.04 LTS Trusty Tahr & Mac OS X 10.6.8
