### PR TITLE
metadata update, v1.2.8 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {   "name": "n"
   , "description": "node version manager"
-  , "version": "1.2.1"
+  , "version": "1.2.8"
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"
   , "homepage": "https://github.com/visionmedia/n"
   , "bugs": "https://github.com/visionmedia/n/issues"
-  , "keywords": ["node", "binary", "version", "env"]
+  , "keywords": ["node", "binary", "version", "manager", "switcher", "env" ]
   , "bin": { "n": "./bin/n" }
   , "repository": { "type": "git", "url": "git://github.com/visionmedia/n.git" }
+  , "preferGlobal": true
+  , "os": [ "!win32" ]
   , "engines": { "node": "*" }
   , "license": "MIT"
 }


### PR DESCRIPTION
- update package.json constraints, added keywords
- bumped version due to back-filled npm versions
- preferGlobal=true
