### PR TITLE
Add double quotes around ${@}, otherwise it's just like $* and breaks on spaces

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -364,7 +364,7 @@ execute_with_version() {
   shift # remove version
 
   if test -f $bin; then
-    $bin $@
+    $bin "$@"
   else
     abort "$version is not installed"
   fi


### PR DESCRIPTION
Add double quotes around ${@}, otherwise it's just like $\* and breaks on spaces.

See: https://github.com/koalaman/shellcheck/wiki/SC2068
