### PR TITLE
n now prints help when no version is installed, fixes #188

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -53,7 +53,7 @@ display_help() {
 
   Commands:
 
-    n                            Output versions installed
+    n                            Output versions installed or help information if no version is installed
     n latest                     Install or activate the latest node release
     n stable                     Install or activate the latest stable node release
     n <version>                  Install node <version>
@@ -426,7 +426,7 @@ display_remote_versions() {
 #
 
 if test $# -eq 0; then
-  test "$(ls -l $VERSIONS_DIR | grep ^d)" || abort "no installed version"
+  test "$(ls -l $VERSIONS_DIR | grep ^d)" || display_help
   display_versions
 else
   while test $# -ne 0; do


### PR DESCRIPTION
Attempt to close #188
PR was requested, and here's my take on it.

Would like to add an error message but both abort and display_help exits and I figured logging it feels awkward?
