### PR TITLE
Adding signed binaries for mac os. (fixes #199)

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -226,6 +226,7 @@ tarball_url() {
   local uname="$(uname -a)"
   local arch=x86
   local os=
+  local url=
 
   # from nave(1)
   case "$uname" in
@@ -239,7 +240,13 @@ tarball_url() {
     *armv6l*) arch=arm-pi ;;
   esac
 
-  echo "${N_MIRROR}v${version}/node-v${version}-${os}-${arch}.tar.gz"
+  if [[ $os == darwin ]]; then
+    url="${N_MIRROR}v${version}/node-v${version}.pkg"
+  else
+    url="${N_MIRROR}v${version}/node-v${version}-${os}-${arch}.tar.gz"
+  fi
+
+  echo $url
 }
 
 #
@@ -316,7 +323,18 @@ install_node() {
   cd $dir
 
   log fetch $url
-  curl -L# $url | tar -zx --strip 1
+  if [[ $url == *.pkg ]] ; then
+      curl -L# $url -o node-v$version.pkg
+      pkgutil --expand node-v$version.pkg /tmp/node-v$version
+      cp /tmp/node-v$version/local.pkg/Payload .
+      cat Payload | gzip -d | cpio -id
+      rm Payload
+      rm -rf /tmp/node-v$version
+      rm node-v$version.pkg
+  else
+      curl -L# $url | tar -zx --strip 1
+  fi
+
   erase_line
   rm -f $dir/n.lock
 


### PR DESCRIPTION
Mac os's firewall can be a pain when unsigned binaries want to
listen to ports (privileged or not) and will not remember firewall
permissions for the unsigned binary. This commit addresses the issue
by downloading the `.pkg` file (which has signed binaries) from nodejs.org
and unpacking it.