### PR TITLE
Use tput instead of clear. Closes #196

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -209,7 +209,7 @@ display_versions() {
   trap handle_sigtstp SIGTSTP
 
   while true; do
-    read -s -n 3 c
+    read -n 3 c
     case "$c" in
       $UP)
         clear


### PR DESCRIPTION
Instead of clearing the screen, use `tput smcup` and `tput rmcup`.

Screenshots:
![n-screenshot-1](https://cloud.githubusercontent.com/assets/4295266/4782786/8b61457a-5d06-11e4-823e-558b639a4235.png)
![n-screenshot-2](https://cloud.githubusercontent.com/assets/4295266/4782787/8f027640-5d06-11e4-9a66-7ad6e83808fb.png)
![n-screenshot-3](https://cloud.githubusercontent.com/assets/4295266/4782788/9171ff9a-5d06-11e4-9b53-1819d498afc4.png)
