### PR TITLE
Reorder arguments of 'find' to suppress warning

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -218,7 +218,7 @@ check_current_version() {
 #
 
 versions_paths() {
-  find $BASE_VERSIONS_DIR -type d -maxdepth 2 \
+  find $BASE_VERSIONS_DIR -maxdepth 2 -type d \
     | sed 's|'$BASE_VERSIONS_DIR'/||g' \
     | egrep "/[0-9]+\.[0-9]+\.[0-9]+$" \
     | sort -k 1,1n -k 2,2n -k 3,3n -t .


### PR DESCRIPTION
GNU `find` complains about the current ordering of its arguments: `find: warning: you have specified the -maxdepth option after a non-option argument -type, but options are not positional (-maxdepth affects tests specified before it as well as those specified after it). Please specify options before other arguments.`

This pull request fixes that.