### PR TITLE
fix the activation fails when a target subdirectory is a symlink

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -373,8 +373,13 @@ activate() {
   if test "$version" != "$active"; then
     local dir=$BASE_VERSIONS_DIR/$version
     echo $active > $BASE_VERSIONS_DIR/.prev
-    cp -fR $dir/bin $dir/lib $dir/share $N_PREFIX
-    [[ -d "$dir/include" ]] && cp -fR $dir/include $N_PREFIX
+    for subdir in bin lib include share; do
+      if test -L "$N_PREFIX/$subdir"; then
+        find "$dir/$subdir" -mindepth 1 -maxdepth 1 -exec cp -fR "{}" "$N_PREFIX/$subdir" \;
+      else
+        cp -fR "$dir/$subdir" $N_PREFIX
+      fi
+    done
   fi
 }
 


### PR DESCRIPTION
In Gentoo /usr/local/lib is symlink to lib64 and cp fails with error:
> cp: cannot overwrite non-directory '/usr/local/lib' with directory '/usr/local/n/versions/io/1.2.0/lib'
