### PR TITLE
make sure install directory exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 PREFIX ?= /usr/local
 
 install: bin/n
+	mkdir -p $(PREFIX)/$(dir $<)
 	cp $< $(PREFIX)/$<
 
 uninstall:


### PR DESCRIPTION
'make install' fails when installing to a $PREFIX where bin/ doesn't exist yet. Make the directory before copying.