### PR TITLE
Adding support for ARMv6 and ARMv7

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -318,7 +318,8 @@ tarball_url() {
 
   case "$uname" in
     *x86_64*) arch=x64 ;;
-    *armv6l*) arch=arm-pi ;;
+    *armv6l*) arch=armv6l ;;
+    *armv7l*) arch=armv7l ;;
   esac
 
   echo "${MIRROR[$DEFAULT]}v${version}/${BIN_NAME[$DEFAULT]}-v${version}-${os}-${arch}.tar.gz"


### PR DESCRIPTION
This change adds support for ARMv6 (Raspberry Pi) and ARMv7 (Raspberry Pi 2). I think that the architecture for ARMv6 was used to be called "arm-pi" because that's the way the older dists of Node.js call their packages for ARMv6. However, io.js' dists call them armv6l and armv7l since there's a new Raspberry Pi 2 with ARMv7 and they want to support both. This change also means the end of support for older Node.js versions on ARMv6 devices with n, however, once Node.js will support ARMs again (from what I've heard the human build bot will do it again soon), they'll probably use the same names to support both Pis as well.

Update: With the recent commit on this branch in this pull request, ARMv6 versions of older Node.js versions are supported again.