### PR TITLE
Fixing problem with older Node.js versions than v0.10.24

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -335,11 +335,8 @@ activate() {
   if test "$version" != "$active"; then
     local dir=$BASE_VERSIONS_DIR/$version
     echo $active > $BASE_VERSIONS_DIR/.prev
-    if [ -d "$dir/include" ]; then
-      cp -fR $dir/bin $dir/lib $dir/include $dir/share $N_PREFIX
-    else
-      cp -fR $dir/bin $dir/lib $dir/share $N_PREFIX
-    fi
+    cp -fR $dir/bin $dir/lib $dir/share $N_PREFIX
+    [[ -d "$dir/iclude" ]] && cp -fR $dir/include
   fi
 }
 

--- a/bin/n
+++ b/bin/n
@@ -335,7 +335,11 @@ activate() {
   if test "$version" != "$active"; then
     local dir=$BASE_VERSIONS_DIR/$version
     echo $active > $BASE_VERSIONS_DIR/.prev
-    cp -fR $dir/bin $dir/lib $dir/include $dir/share $N_PREFIX
+    if [ -d "$dir/include" ]; then
+      cp -fR $dir/bin $dir/lib $dir/include $dir/share $N_PREFIX
+    else
+      cp -fR $dir/bin $dir/lib $dir/share $N_PREFIX
+    fi
   fi
 }
 


### PR DESCRIPTION
In older Node.js versions than v0.10.24, there's no `include` folder, and therefore nothing for cp to copy.
This fix will prevent cp from throwing an error like:
```
cp: cannot stat `/usr/local/n/versions/node/0.10.10/include': No such file or directory
```