### PR TITLE
Remove prev, iojs alias, add quiet mode and more.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,10 +44,6 @@ Use or install the stable official release:
 
     $ n stable
 
-Switch to the previous version you were using:
-
-    $ n prev
-
 ### Removing Binaries
 
 Remove some versions:
@@ -82,7 +78,6 @@ with flags:
 
     Environments:
      n [COMMAND] [args]            Uses default env (node)
-     n node [COMMAND] [args]       Sets env as node
      n io [COMMAND]                Sets env as io
 
     Commands:
@@ -94,7 +89,6 @@ with flags:
       n use <version> [args ...]   Execute node <version> with [args ...]
       n bin <version>              Output bin path for <version>
       n rm <version ...>           Remove the given version(s)
-      n prev                       Revert to the previously activated version
       n --latest                   Output the latest node version available
       n --stable                   Output the latest stable node version available
       n ls                         Output the versions of node available
@@ -102,23 +96,21 @@ with flags:
     (iojs):
     
       n io latest                    Install or activate the latest iojs release
-      n io stable                    Install or activate the latest stable iojs release
       n io <version>                 Install iojs <version>
       n io use <version> [args ...]  Execute iojs <version> with [args ...]
       n io bin <version>             Output bin path for <version>
       n io rm <version ...>          Remove the given version(s)
       n io --latest                  Output the latest iojs version available
-      n io --stable                  Output the latest stable iojs version available
       n io ls                        Output the versions of iojs available
  		 
     Options:
 
       -V, --version   Output current version of n
       -h, --help      Display help information
+      -q, --quiet     Disable curl output (if available)
 
     Aliases:
 
-      iojs    io
       which   bin
       use     as
       list    ls

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,7 @@
 # n
 
+[![Join the chat at https://gitter.im/tj/n](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tj/n?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 Simple flavour of node/iojs binary management, no subshells, no profile setup, no convoluted api, just _simple_.
 
  ![](https://i.cloudup.com/59cA8VEDae.gif)

--- a/bin/n
+++ b/bin/n
@@ -210,6 +210,14 @@ check_current_version() {
 }
 
 #
+# Check the operation is supported for io.
+#
+
+check_io_supported() {
+  test $DEFAULT -eq 1 && abort "$1 not supported for io.js"
+}
+
+#
 # Display sorted versions directories paths.
 #
 
@@ -353,6 +361,7 @@ install_latest() {
 #
 
 install_stable() {
+  check_io_supported "stable"
   install $(display_latest_stable_version)
 }
 
@@ -481,7 +490,7 @@ display_latest_version() {
 #
 
 display_latest_stable_version() {
-  test $DEFAULT -eq 1 && abort "stable not supported for io.js"
+  check_io_supported "--stable"
 
   $GET 2> /dev/null ${MIRROR[$DEFAULT]} \
     | egrep -o '[0-9]+\.[0-9]*[02468]\.[0-9]+' \

--- a/bin/n
+++ b/bin/n
@@ -4,7 +4,7 @@
 # Setup.
 #
 
-VERSION="1.3.0"
+VERSION="1.4.0"
 UP=$'\033[A'
 DOWN=$'\033[B'
 N_PREFIX=${N_PREFIX-/usr/local}
@@ -30,7 +30,7 @@ VERSIONS_DIR=($BASE_VERSIONS_DIR/node
 DEFAULT=0
 
 #
-# set_default <bin_name>
+# set_default <BIN_NAME>
 #
 
 set_default() {
@@ -109,7 +109,6 @@ display_help() {
 
   Environments:
     n [COMMAND] [args]            Uses default env (node)
-    n node [COMMAND] [args]       Sets env as node
     n io [COMMAND]                Sets env as io
 
   Commands:
@@ -121,30 +120,27 @@ display_help() {
     n use <version> [args ...]     Execute node <version> with [args ...]
     n bin <version>                Output bin path for <version>
     n rm <version ...>             Remove the given version(s)
-    n prev                         Revert to the previously activated version
     n --latest                     Output the latest node version available
     n --stable                     Output the latest stable node version available
     n ls                           Output the versions of node available
 
   (iojs):
     n io latest                    Install or activate the latest iojs release
-    n io stable                    Install or activate the latest stable iojs release
     n io <version>                 Install iojs <version>
     n io use <version> [args ...]  Execute iojs <version> with [args ...]
     n io bin <version>             Output bin path for <version>
     n io rm <version ...>          Remove the given version(s)
     n io --latest                  Output the latest iojs version available
-    n io --stable                  Output the latest stable iojs version available
     n io ls                        Output the versions of iojs available
 
   Options:
 
     -V, --version   Output current version of n
     -h, --help      Display help information
+    -q, --quiet     Disable curl output (if available)
 
   Aliases:
 
-    iojs    io
     which   bin
     use     as
     list    ls
@@ -339,24 +335,9 @@ activate() {
   check_current_version
   if test "$version" != "$active"; then
     local dir=$BASE_VERSIONS_DIR/$version
-    echo $active > $BASE_VERSIONS_DIR/.prev
     cp -fR $dir/bin $dir/lib $dir/share $N_PREFIX
     [[ -d "$dir/include" ]] && cp -fR $dir/include $N_PREFIX
   fi
-}
-
-#
-# Activate previous node.
-#
-
-activate_previous() {
-  test -f $BASE_VERSIONS_DIR/.prev || abort "no previous versions activated"
-  local prev=$(cat $BASE_VERSIONS_DIR/.prev)
-  test -d $BASE_VERSIONS_DIR/$prev || abort "previous version $prev not installed"
-  activate $prev
-  echo
-  log activate $prev
-  echo
 }
 
 #
@@ -380,7 +361,6 @@ install() {
   fi
 
   local dir=${VERSIONS_DIR[$DEFAULT]}/$version
-  local url=$(tarball_url $version)
 
   if test -d $dir; then
     if [[ ! -e $dir/n.lock ]] ; then
@@ -391,6 +371,8 @@ install() {
 
   echo
   log install ${BINS[$DEFAULT]}-v$version
+
+  local url=$(tarball_url $version)
 
   is_ok $url || abort "invalid version $version"
 
@@ -405,13 +387,21 @@ install() {
   cd $dir
 
   log fetch $url
-  curl -L# $url | tar -zx --strip 1
+  $GET $url | tar -zx --strip 1
   erase_line
   rm -f $dir/n.lock
 
   activate ${BINS[$DEFAULT]}/$version
   log installed $(node --version)
   echo
+}
+
+#
+# Set curl to quiet (silent) mode.
+#
+
+set_quiet() {
+  command -v curl > /dev/null && GET="$GET -s"
 }
 
 #
@@ -435,7 +425,7 @@ display_bin_path_for_version() {
   local version=${1#v}
   local bin=${VERSIONS_DIR[$DEFAULT]}/$version/bin/node
   if test -f $bin; then
-    printf $bin
+    printf "$bin \n"
   else
     abort "$1 is not installed"
   fi
@@ -459,15 +449,15 @@ execute_with_version() {
   fi
 }
 
+NODE_STABLE_VERSION='[0-9]+\.[0-9]*[02468]\.[0-9]+'
+LATEST_VERSION='[0-9]+\.[0-9]+\.[0-9]+'
+
 #
 # Display the latest release version.
 #
 
 display_latest_version() {
-  $GET 2> /dev/null ${MIRROR[$DEFAULT]} \
-    | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' \
-    | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
-    | tail -n1
+  fetch_version $LATEST_VERSION
 }
 
 #
@@ -475,8 +465,20 @@ display_latest_version() {
 #
 
 display_latest_stable_version() {
+  if test $DEFAULT -eq 0; then
+    fetch_version $NODE_STABLE_VERSION
+  else
+    fetch_version $LATEST_VERSION
+  fi
+}
+
+#
+# Fetch version from mirror.
+#
+
+fetch_version() {
   $GET 2> /dev/null ${MIRROR[$DEFAULT]} \
-    | egrep -o '[0-9]+\.[0-9]*[02468]\.[0-9]+' \
+    | egrep -o $1 \
     | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
     | tail -n1
 }
@@ -523,16 +525,16 @@ else
     case $1 in
       -V|--version) display_n_version ;;
       -h|--help|help) display_help ;;
+      -q|--quiet) set_quiet ;;
       --latest) display_latest_version; exit ;;
       --stable) display_latest_stable_version; exit ;;
-      io|iojs|node) set_default $1;; # set bin and continue
+      io) set_default $1 ;; # set bin and continue
       bin|which) display_bin_path_for_version $2; exit ;;
       as|use) shift; execute_with_version $@; exit ;;
       rm|-) shift; remove_versions $@; exit ;;
-      latest) install $($0 ${BINS[$DEFAULT]} --latest); exit ;;
-      stable) install $($0 ${BINS[$DEFAULT]} --stable); exit ;;
+      latest) install $($0 --latest); exit ;;
+      stable) install $($0 --stable); exit ;;
       ls|list) display_remote_versions; exit ;;
-      prev) activate_previous; exit ;;
       *) install $1; exit ;;
     esac
     shift

--- a/bin/n
+++ b/bin/n
@@ -28,6 +28,7 @@ VERSIONS_DIR=($BASE_VERSIONS_DIR/node
 #
 
 DEFAULT=0
+QUIET=true
 
 #
 # set_default <BIN_NAME>
@@ -70,7 +71,7 @@ GET=
 # wget support (Added --no-check-certificate for Github downloads)
 command -v wget > /dev/null && GET="wget --no-check-certificate -q -O-"
 
-command -v curl > /dev/null && GET="curl -# -L"
+command -v curl > /dev/null && GET="curl -# -L" && QUIET=false
 
 test -z "$GET" && abort "curl or wget required"
 
@@ -300,7 +301,11 @@ erase_line() {
 #
 
 is_ok() {
-  curl -Is $1 | head -n 1 | grep 200 > /dev/null
+  if command -v curl > /dev/null; then
+    curl -Is $1 | head -n 1 | grep 200 > /dev/null
+  else
+    $GET -S --spider 2>&1 $1 | head -n 1 | grep 200 > /dev/null
+  fi
 }
 
 #
@@ -413,7 +418,7 @@ install() {
 
   log fetch $url
   $GET $url | tar -zx --strip 1
-  erase_line
+  [ $QUIET == false ] && erase_line
   rm -f $dir/n.lock
 
   activate ${BINS[$DEFAULT]}/$version
@@ -426,7 +431,7 @@ install() {
 #
 
 set_quiet() {
-  command -v curl > /dev/null && GET="$GET -s"
+  command -v curl > /dev/null && GET="$GET -s" && QUIET=true
 }
 
 #

--- a/bin/n
+++ b/bin/n
@@ -4,7 +4,7 @@
 # Setup.
 #
 
-VERSION="1.4.0"
+VERSION="2.0.0"
 UP=$'\033[A'
 DOWN=$'\033[B'
 N_PREFIX=${N_PREFIX-/usr/local}
@@ -465,15 +465,15 @@ execute_with_version() {
   fi
 }
 
-NODE_STABLE_VERSION='[0-9]+\.[0-9]*[02468]\.[0-9]+'
-LATEST_VERSION='[0-9]+\.[0-9]+\.[0-9]+'
-
 #
 # Display the latest release version.
 #
 
 display_latest_version() {
-  fetch_version $LATEST_VERSION
+  $GET 2> /dev/null ${MIRROR[$DEFAULT]} \
+    | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' \
+    | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
+    | tail -n1
 }
 
 #
@@ -481,20 +481,10 @@ display_latest_version() {
 #
 
 display_latest_stable_version() {
-  if test $DEFAULT -eq 0; then
-    fetch_version $NODE_STABLE_VERSION
-  else
-    fetch_version $LATEST_VERSION
-  fi
-}
+  test $DEFAULT -eq 1 && abort "stable not supported for io.js"
 
-#
-# Fetch version from mirror.
-#
-
-fetch_version() {
   $GET 2> /dev/null ${MIRROR[$DEFAULT]} \
-    | egrep -o $1 \
+    | egrep -o '[0-9]+\.[0-9]*[02468]\.[0-9]+' \
     | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
     | tail -n1
 }

--- a/bin/n
+++ b/bin/n
@@ -513,6 +513,14 @@ display_remote_versions() {
   echo
 }
 
+install_latest() {
+  install $(display_latest_version)
+}
+
+install_stable() {
+  install $(display_latest_stable_version)
+}
+
 #
 # Handle arguments.
 #
@@ -532,8 +540,8 @@ else
       bin|which) display_bin_path_for_version $2; exit ;;
       as|use) shift; execute_with_version $@; exit ;;
       rm|-) shift; remove_versions $@; exit ;;
-      latest) install $($0 --latest); exit ;;
-      stable) install $($0 --stable); exit ;;
+      latest) install_latest; exit ;;
+      stable) install_stable; exit ;;
       ls|list) display_remote_versions; exit ;;
       *) install $1; exit ;;
     esac

--- a/bin/n
+++ b/bin/n
@@ -341,6 +341,22 @@ activate() {
 }
 
 #
+# Install latest version.
+#
+
+install_latest() {
+  install $(display_latest_version)
+}
+
+#
+# Install latest stable version.
+#
+
+install_stable() {
+  install $(display_latest_stable_version)
+}
+
+#
 # Install <version>
 #
 
@@ -425,7 +441,7 @@ display_bin_path_for_version() {
   local version=${1#v}
   local bin=${VERSIONS_DIR[$DEFAULT]}/$version/bin/node
   if test -f $bin; then
-    printf "$bin \n"
+    echo $bin
   else
     abort "$1 is not installed"
   fi
@@ -511,14 +527,6 @@ display_remote_versions() {
     fi
   done
   echo
-}
-
-install_latest() {
-  install $(display_latest_version)
-}
-
-install_stable() {
-  install $(display_latest_stable_version)
 }
 
 #

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n",
   "description": "node version manager",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "homepage": "https://github.com/tj/n",
   "bugs": "https://github.com/tj/n/issues",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n",
   "description": "node version manager",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "homepage": "https://github.com/tj/n",
   "bugs": "https://github.com/tj/n/issues",


### PR DESCRIPTION
Some changes to the script, readme file and package.json file.

- Pulled `prev` from the script and documentation as discussed in issue #184.
- Pulled the `iojs` alias from the script and documentation because it never worked as described in issue #255.
- Added a quiet mode option (`-q` or `--quiet`) for curl to not display the progress bar as requested in issue #205.
  - Fixed a "bug" in the `install` function where curl was hard coded to get the tarball instead of what is set in the GET variable.
  - I also moved the call to `tarball_url` in the `install` function below the test for an already installed version. It is a waste to build the url every time and not use it.
- I pulled documentation for `n io stable` and `n io --stable` but they still work. They actually work correctly now for `io` by always calling latest. This was brought up in issue #230 and I sat on it for a bit. I decided that this would be best for now because it provides backward compatibility.

I also added some minor items from other PRs:
#241 - Added Gitter badge
#239 - Calling `n bin` would not advance the shell prompt to a new line. I just switched `printf` to `echo`.

One final item I pulled is the `node` keyword which called `set_default`. It looks like noise because the default state for `n` would be to install node. I also need the keyword for a feature request in issue #185. To preserve script state I had to add separate functions to install latest and stable so it remembers which mirror to use.

And as @tjwebb said in issue #184 the version was changed to 1.4.0 in the script and package.json files. Or should it be 2.0.0? And if we go to version 2.0.0, maybe I should just make calls to `n io (--)stable` abort?