### PR TITLE
Add new "download only option"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ Simple flavour of node/iojs binary management, no subshells, no profile setup, n
 or
 
     $ make install
-    
+
 to `$HOME`. Prefix later calls to `n` with `N_PREFIX=$HOME`
 
     $ PREFIX=$HOME make install
@@ -77,7 +77,7 @@ with flags:
 ## Usage
 
  Output from `n --help`:
- 
+
     Usage: n [options/env] [COMMAND] [args]
 
     Environments:
@@ -100,7 +100,7 @@ with flags:
       n ls                         Output the versions of node available
 
     (iojs):
-    
+
       n io latest                    Install or activate the latest iojs release
       n io stable                    Install or activate the latest stable iojs release
       n io <version>                 Install iojs <version>
@@ -110,11 +110,12 @@ with flags:
       n io --latest                  Output the latest iojs version available
       n io --stable                  Output the latest stable iojs version available
       n io ls                        Output the versions of iojs available
- 		 
+
     Options:
 
       -V, --version   Output current version of n
       -h, --help      Display help information
+      -d, --download  Download only
 
     Aliases:
 

--- a/bin/n
+++ b/bin/n
@@ -141,6 +141,7 @@ display_help() {
 
     -V, --version   Output current version of n
     -h, --help      Display help information
+    -d, --download  Download only
 
   Aliases:
 

--- a/bin/n
+++ b/bin/n
@@ -384,9 +384,10 @@ install() {
 
   if test -d $dir; then
     if [[ ! -e $dir/n.lock ]] ; then
-      if [ "$2" != "-d" ]; then
-        activate ${BINS[$DEFAULT]}/$version
+      if [ "$2" == "-d" -o "$2" == "--download" ]; then
+        exit
       fi
+      activate ${BINS[$DEFAULT]}/$version
       exit
     fi
   fi
@@ -411,11 +412,13 @@ install() {
   erase_line
   rm -f $dir/n.lock
 
-  if [ "$2" != "-d" ]; then
+  if [ "$2" == "-d" -o "$2" == "--download" ]; then
+    echo
+  else
     activate ${BINS[$DEFAULT]}/$version
+    log installed $(node --version)
+    echo
   fi
-  log installed $(node --version)
-  echo
 }
 
 #

--- a/bin/n
+++ b/bin/n
@@ -321,9 +321,9 @@ tarball_url() {
     *armv6l*) arch=armv6l ;;
     *armv7l*) arch=armv7l ;;
   esac
-  
+
   if [ ${arch} = "armv6l" -a ${BIN_NAME[$DEFAULT]} = node ]; then
-    arch=arm-pi 
+    arch=arm-pi
   fi
 
   echo "${MIRROR[$DEFAULT]}v${version}/${BIN_NAME[$DEFAULT]}-v${version}-${os}-${arch}.tar.gz"
@@ -384,7 +384,9 @@ install() {
 
   if test -d $dir; then
     if [[ ! -e $dir/n.lock ]] ; then
-      activate ${BINS[$DEFAULT]}/$version
+      if [ "$2" != "-d" ]; then
+        activate ${BINS[$DEFAULT]}/$version
+      fi
       exit
     fi
   fi
@@ -409,7 +411,9 @@ install() {
   erase_line
   rm -f $dir/n.lock
 
-  activate ${BINS[$DEFAULT]}/$version
+  if [ "$2" != "-d" ]; then
+    activate ${BINS[$DEFAULT]}/$version
+  fi
   log installed $(node --version)
   echo
 }
@@ -533,7 +537,7 @@ else
       stable) install $($0 ${BINS[$DEFAULT]} --stable); exit ;;
       ls|list) display_remote_versions; exit ;;
       prev) activate_previous; exit ;;
-      *) install $1; exit ;;
+      *) install $1 $2; exit ;;
     esac
     shift
   done

--- a/bin/n
+++ b/bin/n
@@ -28,6 +28,7 @@ VERSIONS_DIR=($BASE_VERSIONS_DIR/node
 #
 
 DEFAULT=0
+ACTIVATE=true
 
 #
 # set_default <bin_name>
@@ -385,10 +386,9 @@ install() {
 
   if test -d $dir; then
     if [[ ! -e $dir/n.lock ]] ; then
-      if [ "$2" == "-d" -o "$2" == "--download" ]; then
-        exit
+      if $ACTIVATE ; then
+        activate ${BINS[$DEFAULT]}/$version
       fi
-      activate ${BINS[$DEFAULT]}/$version
       exit
     fi
   fi
@@ -413,13 +413,11 @@ install() {
   erase_line
   rm -f $dir/n.lock
 
-  if [ "$2" == "-d" -o "$2" == "--download" ]; then
-    echo
-  else
+  if $ACTIVATE ; then
     activate ${BINS[$DEFAULT]}/$version
     log installed $(node --version)
-    echo
   fi
+  echo
 }
 
 #
@@ -531,6 +529,7 @@ else
     case $1 in
       -V|--version) display_n_version ;;
       -h|--help|help) display_help ;;
+      -d|--download) ACTIVATE=false ;;
       --latest) display_latest_version; exit ;;
       --stable) display_latest_stable_version; exit ;;
       io|iojs|node) set_default $1;; # set bin and continue
@@ -541,7 +540,7 @@ else
       stable) install $($0 ${BINS[$DEFAULT]} --stable); exit ;;
       ls|list) display_remote_versions; exit ;;
       prev) activate_previous; exit ;;
-      *) install $1 $2; exit ;;
+      *) install $1; exit ;;
     esac
     shift
   done


### PR DESCRIPTION
This change supports a new "download only" argument, `-d`, with which the selected node/iojs version just gets downloaded and saved, but not activated, as requested in #262.
This however only works with `n (io) <version> -d`, not with `n (io) latest/stable`, as an automatic download of the most current/stable version with the intention to not use it wouldn't really make sense to me. Feedback is very welcome.

(Fix of #264)