### PR TITLE
Replaced --strip with --strip-components

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -405,7 +405,7 @@ install() {
   cd $dir
 
   log fetch $url
-  curl -L# $url | tar -zx --strip 1
+  curl -L# $url | tar -zx --strip-components=1
   erase_line
   rm -f $dir/n.lock
 


### PR DESCRIPTION
Fix for issue #260 where --strip is not recognized.