### PR TITLE
Support upcoming Nodejs ARMv6 builds

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -324,8 +324,8 @@ tarball_url() {
 
   if [ ${arch} = "armv6l" -a ${BIN_NAME[$DEFAULT]} = node ]; then
     local semver=${version//./ }
-    local major=$semver | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//'
-    local minor=$semver | awk '{print $2}' | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//'
+    local major=$(echo $semver | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//')
+    local minor=$(echo $semver | awk '{print $2}' | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//')
     [[ $major -eq "" && $minor -lt 12 ]] && arch=arm-pi
   fi
 

--- a/bin/n
+++ b/bin/n
@@ -321,9 +321,12 @@ tarball_url() {
     *armv6l*) arch=armv6l ;;
     *armv7l*) arch=armv7l ;;
   esac
-  
+
   if [ ${arch} = "armv6l" -a ${BIN_NAME[$DEFAULT]} = node ]; then
-    arch=arm-pi 
+    local semver=${version//./ }
+    local major=$semver | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//'
+    local minor=$semver | awk '{print $2}' | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//'
+    [[ $major -eq "" && $minor -lt 12 ]] && arch=arm-pi
   fi
 
   echo "${MIRROR[$DEFAULT]}v${version}/${BIN_NAME[$DEFAULT]}-v${version}-${os}-${arch}.tar.gz"


### PR DESCRIPTION
After the merge process of Node.js and io.js is done, we probably can expect ARMv6 builds of Node.js again, as the version of V8 that is being used by io.js that will then be used for the new Node.js allows it easier to build for ARMv6, and since the io.js maintainers provided ARMv6 builds, the new Node.js will probably as well. This PR simply does a check if the given version is below 0.12.0, and then sets the `arch` right for ARMv6 devices. Older Node.js builds require `arm-pi` whereas io.js builds (and most likely the most likely upcoming builds of Node.js as well) require `armv6l`.