### PR TITLE
only extract version numbers from lines which contain <a></a> tags

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -369,6 +369,7 @@ install() {
   local dots=$(echo $version | sed 's/[^.]*//g')
   if test ${#dots} -eq 1; then
     version=$($GET 2> /dev/null ${MIRROR[DEFAULT]} \
+      | egrep "</a>" \
       | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' \
       | egrep -v '^0\.[0-7]\.' \
       | egrep -v '^0\.8\.[0-5]$' \
@@ -465,6 +466,7 @@ execute_with_version() {
 
 display_latest_version() {
   $GET 2> /dev/null ${MIRROR[$DEFAULT]} \
+    | egrep "</a>" \
     | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' \
     | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
     | tail -n1
@@ -476,6 +478,7 @@ display_latest_version() {
 
 display_latest_stable_version() {
   $GET 2> /dev/null ${MIRROR[$DEFAULT]} \
+    | egrep "</a>" \
     | egrep -o '[0-9]+\.[0-9]*[02468]\.[0-9]+' \
     | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
     | tail -n1
@@ -489,6 +492,7 @@ display_remote_versions() {
   check_current_version
   local versions=""
   versions=$($GET 2> /dev/null ${MIRROR[$DEFAULT]} \
+    | egrep "</a>" \
     | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' \
     | egrep -v '^0\.[0-7]\.' \
     | egrep -v '^0\.8\.[0-5]$' \


### PR DESCRIPTION
This mirror website is popular in Asia

```
http://npm.taobao.org/mirrors/node/
```

I have problems installing nodejs using customized mirror website

```sh
NODE_MIRROR=http://npm.taobao.org/mirrors/node/ n ls
```

because `3.2.0` pops up in the list as shown below

```text
    ...
    0.11.12
    0.11.13
    0.11.14
    0.11.15
    0.11.16
    0.12.0
    0.12.1
    0.12.2
    0.12.3
    0.12.4
    3.2.0
```
I try to find the root cause by myself, it turns out the mirror website source code contains links to  bootstrap

```html
    <link href="//dn-staticfile.qbox.me/twitter-bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet" media="screen">
```

so, the problem can be fixed by prepending another `egrep`
```sh
| egrep "</a>" \
```

