### PR TITLE
Add -a|--arch option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -76,6 +76,19 @@ with flags:
 
     $ n as 0.9.4 --debug some.js
 
+### Different Architectures
+
+By default `n` picks the binaries matching your system architecture, e.g. `n` will download 64 bit binaries for a 64 bit system. You can override this by using the `-a` or `--arch` option.
+
+Download and use latest 32 bit version of node:
+
+    $ n --arch x86 latest
+
+Download and use latest 32 bit version of iojs:
+
+    $ n io --arch x86 latest
+
+
 ## Usage
 
  Output from `n --help`:
@@ -83,27 +96,29 @@ with flags:
     Usage: n [options/env] [COMMAND] [args]
 
     Environments:
-     n [COMMAND] [args]            Uses default env (node)
-     n node [COMMAND] [args]       Sets env as node
-     n io [COMMAND]                Sets env as io
+     n [COMMAND] [args]              Uses default env (node)
+     n node [COMMAND] [args]         Sets env as node
+     n io [COMMAND]                  Sets env as io
 
     Commands:
 
-      n                            Output versions installed
-      n latest                     Install or activate the latest node release
-      n stable                     Install or activate the latest stable node release
-      n <version>                  Install node <version>
-      n use <version> [args ...]   Execute node <version> with [args ...]
-      n bin <version>              Output bin path for <version>
-      n rm <version ...>           Remove the given version(s)
-      n prev                       Revert to the previously activated version
-      n --latest                   Output the latest node version available
-      n --stable                   Output the latest stable node version available
-      n ls                         Output the versions of node available
+      n                              Output versions installed
+      n latest                       Install or activate the latest node release
+      n -a x86 latest                As above but force 32 bit architecture
+      n stable                       Install or activate the latest stable node release
+      n <version>                    Install node <version>
+      n use <version> [args ...]     Execute node <version> with [args ...]
+      n bin <version>                Output bin path for <version>
+      n rm <version ...>             Remove the given version(s)
+      n prev                         Revert to the previously activated version
+      n --latest                     Output the latest node version available
+      n --stable                     Output the latest stable node version available
+      n ls                           Output the versions of node available
 
     (iojs):
     
       n io latest                    Install or activate the latest iojs release
+      n io -a x86 latest             As above but force 32 bit architecture
       n io stable                    Install or activate the latest stable iojs release
       n io <version>                 Install iojs <version>
       n io use <version> [args ...]  Execute iojs <version> with [args ...]
@@ -115,8 +130,9 @@ with flags:
  		 
     Options:
 
-      -V, --version   Output current version of n
-      -h, --help      Display help information
+      -V, --version                  Output current version of n
+      -h, --help                     Display help information
+      -a, --arch                     Override system architecture
 
     Aliases:
 

--- a/bin/n
+++ b/bin/n
@@ -121,14 +121,15 @@ display_help() {
   Usage: n [options/env] [COMMAND] [args]
 
   Environments:
-    n [COMMAND] [args]            Uses default env (node)
-    n node [COMMAND] [args]       Sets env as node
-    n io [COMMAND]                Sets env as io
+    n [COMMAND] [args]             Uses default env (node)
+    n node [COMMAND] [args]        Sets env as node
+    n io [COMMAND]                 Sets env as io
 
   Commands:
 
     n                              Output versions installed
     n latest                       Install or activate the latest node release
+    n -a x86 latest                As above but force 32 bit architecture
     n stable                       Install or activate the latest stable node release
     n <version>                    Install node <version>
     n use <version> [args ...]     Execute node <version> with [args ...]
@@ -141,6 +142,7 @@ display_help() {
 
   (iojs):
     n io latest                    Install or activate the latest iojs release
+    n io -a x86 latest             As above but force 32 bit architecture
     n io stable                    Install or activate the latest stable iojs release
     n io <version>                 Install iojs <version>
     n io use <version> [args ...]  Execute iojs <version> with [args ...]
@@ -152,8 +154,9 @@ display_help() {
 
   Options:
 
-    -V, --version   Output current version of n
-    -h, --help      Display help information
+    -V, --version                  Output current version of n
+    -h, --help                     Display help information
+    -a, --arch                     Override system architecture
 
   Aliases:
 

--- a/bin/n
+++ b/bin/n
@@ -28,6 +28,7 @@ VERSIONS_DIR=($BASE_VERSIONS_DIR/node
 #
 
 DEFAULT=0
+ARCH=
 
 #
 # set_default <bin_name>
@@ -44,6 +45,18 @@ set_default() {
 for dir in ${VERSIONS_DIR[@]}; do
   test -d $dir || mkdir -p $dir
 done
+
+#
+# set_arch <arch> to override $(uname -a)
+#
+
+set_arch() {
+  if test ! -z $1; then
+    ARCH=$1
+  else
+    abort "missing -a|--arch value"
+  fi
+}
 
 #
 # Log <type> <msg>
@@ -321,10 +334,12 @@ tarball_url() {
     *armv6l*) arch=armv6l ;;
     *armv7l*) arch=armv7l ;;
   esac
-  
+
   if [ ${arch} = "armv6l" -a ${BIN_NAME[$DEFAULT]} = node ]; then
-    arch=arm-pi 
+    arch=arm-pi
   fi
+
+  [ ! -z $ARCH ] && arch=$ARCH
 
   echo "${MIRROR[$DEFAULT]}v${version}/${BIN_NAME[$DEFAULT]}-v${version}-${os}-${arch}.tar.gz"
 
@@ -525,6 +540,7 @@ else
       -h|--help|help) display_help ;;
       --latest) display_latest_version; exit ;;
       --stable) display_latest_stable_version; exit ;;
+      -a|--arch) shift; set_arch $1;; # set arch and continue
       io|iojs|node) set_default $1;; # set bin and continue
       bin|which) display_bin_path_for_version $2; exit ;;
       as|use) shift; execute_with_version $@; exit ;;


### PR DESCRIPTION
On linux you can install and run 32 bit on a 64 bit system.
This change enables doing e.g.:

$ n -a x86 0.12.4
$ n --arch x86 0.12.4
$ n io --arch x86 latest

This is *very* handy when creating prebuilt binaries and want to build for
32 bit systems on a 64 bit system (e.g. leveldown).