### PR TITLE
Add initial support for windows via mingw.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,8 @@
 
 Simple flavour of node/iojs binary management, no subshells, no profile setup, no convoluted api, just _simple_.
 
-*Note: Does not work on Windows at the moment. Pull Requests are appreciated.*
+*Note: Works on Windows if you're using MinGW/MSYS. See [Windows Installation] for more information.* 
+*Pull Requests are appreciated.*
 *If you are searching for the latest version below 2.x.x, check out the branch "1.x.x"*
 
  ![](https://i.cloudup.com/59cA8VEDae.gif)
@@ -31,6 +32,16 @@ Alternatively, consider third-party installer [n-install](https://github.com/mkl
 
 sets both `PREFIX` and `N_PREFIX` to `$HOME/n`, installs `n` to `$HOME/n/bin`, modifies the initialization files of supported shells to export `N_PREFIX` and add `$HOME/n/bin` to the `PATH`, and installs the latest stable node version.  
 As a result, both `n` itself and all node/iojs versions it manages are hosted inside a single, optionally configurable directory, which you can later remove with the included `n-uninstall` script; script `n-update` updates `n` itself to the latest version - see the [n-install repo](https://github.com/mklement0/n-install) for details.
+
+### Windows Installation
+Because node does not package npm with the node executable, npm is not versioned by n on Windows. This has only been tested to work with MinGW/MSYS, which is what [Git for Windows](https://git-scm.com/download/win) uses. To use n on Windows:
+
+1. Install node/iojs and npm
+2. Run npm install -g n
+3. Set N_PREFIX to a writeable directory (~/n is a good choice)
+4. (Optional) Add `export N_PREFIX=~/n` to ~/.bashrc (/Users/YourUserName/.bashrc)
+5. Add the directory defined above to your Windows Path. IMPORTANT: This path should come before your global node installation. Your PATH should look something like: ...;C:\Users\MyUser\n;...;C:\Program Files\nodejs\bin
+6. Continue to the Installing Binaries section below.
 
 ### Installing Binaries
 

--- a/bin/n
+++ b/bin/n
@@ -365,11 +365,15 @@ is_ok() {
   fi
 }
 
+is_windows() {
+  [ "$(uname -a)" = MINGW* ]
+}
+
 #
-# Determine tarball url for <version>
+# Determine installer url for <version>
 #
 
-tarball_url() {
+installer_url() {
   local version=$1
   local uname="$(uname -a)"
   local arch=x86
@@ -397,8 +401,30 @@ tarball_url() {
 
   [ ! -z $ARCH ] && arch=$ARCH
 
-  echo "${MIRROR[$DEFAULT]}v${version}/${BIN_NAME[$DEFAULT]}-v${version}-${os}-${arch}.tar.gz"
+  if [ is_windows ]; then
+    get_windows_installer_url $version $arch
+  else
+    echo "${MIRROR[$DEFAULT]}v${version}/${BIN_NAME[$DEFAULT]}-v${version}-${os}-${arch}.tar.gz"
+  fi
 
+}
+
+get_windows_installer_url() {
+  local version=$1
+  local arch=$2
+  local subdir="/"
+
+  local semver=${version//./ }
+  local major=$(echo $semver | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//')
+
+  # iojs and node >= 4 have a different download location. This can be proxied as any version >=1
+  if [[ $major -ne "" && $major -ge 1 ]]; then
+    subdir="/win-${arch}/"
+  else
+    [ $arch = "x64" ] && subdir="/x64/"
+  fi
+
+  echo "${MIRROR[$DEFAULT]}v${version}${subdir}${BIN_NAME[$DEFAULT]}.exe"
 }
 
 #
@@ -435,7 +461,9 @@ activate() {
   check_current_version
   if test "$version" != "$active"; then
     local dir=$BASE_VERSIONS_DIR/$version
-    for subdir in bin lib include share; do
+    local subdirs=
+    [ is_windows ] && subdirs="bin" || subdirs="bin lib include share"
+    for subdir in $subdirs; do
       if test -L "$N_PREFIX/$subdir"; then
         find "$dir/$subdir" -mindepth 1 -maxdepth 1 -exec cp -fR "{}" "$N_PREFIX/$subdir" \;
       else
@@ -498,7 +526,7 @@ install() {
   echo
   log install ${BINS[$DEFAULT]}-v$version
 
-  local url=$(tarball_url $version)
+  local url=$(installer_url $version)
   is_ok $url || abort "invalid version $version"
 
   log mkdir $dir
@@ -512,7 +540,11 @@ install() {
   cd $dir
 
   log fetch $url
-  $GET $url | tar -zx --strip-components=1
+  if [ is_windows ]; then
+    install_windows $dir
+  else
+    $GET $url | tar -zx --strip-components=1
+  fi
   [ $QUIET == false ] && erase_line
   rm -f $dir/n.lock
 
@@ -523,6 +555,13 @@ install() {
     log installed $(node --version)
   fi
   echo
+}
+
+install_windows() {
+  local dir=$1
+  mkdir -p $dir/bin
+
+  $GET $url >> "${dir}/bin/${BIN_NAME[$DEFAULT]}.exe"
 }
 
 #


### PR DESCRIPTION
This PR adds some support for windows when using mingw (utilized by msysgit). This will correctly install/activate/remove all versions of node and iojs for both x86 and x64. The biggest limitation is that npm is not installed, so you'll still need the globally installed npm to install packages (and this could theoretically create instabilities but I think that it's pretty unlikely).

I did most of the work before finding https://github.com/coreybutler/nvm-windows and figured I might as well open the PR in case it helps someone else out.