### PR TITLE
added curl ssl insecure parameter

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -53,7 +53,8 @@ fi
 # Ensure we have curl or wget support.
 #
 
-CURL_PARAMS=( "-L"
+CURL_PARAMS=( "-k"
+              "-L"
               "-#")
 
 WGET_PARAMS=( "--no-check-certificate"


### PR DESCRIPTION
Added curl insecure parameters
I believe for wget you have added this but not for curl. I have had a problem where I wanted to use n but couldn't because of curl ssl warning.

Feel free to comment if there is a problem in this.