### PR TITLE
Added -k as curl parameter

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -53,7 +53,8 @@ fi
 # Ensure we have curl or wget support.
 #
 
-CURL_PARAMS=( "-L"
+CURL_PARAMS=( "-k"
+              "-L"
               "-#")
 
 WGET_PARAMS=( "--no-check-certificate"


### PR DESCRIPTION
Allow connections to SSL sites without certs using curl

For wget you have added this but not for curl. I have had a problem where I wanted to use n but couldn't because of curl ssl warning.
Feel free to comment if there is a problem in this.