### PR TITLE
Sort double-digit semver numbers correctly

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -284,7 +284,7 @@ versions_paths() {
   find $BASE_VERSIONS_DIR -maxdepth 2 -type d \
     | sed 's|'$BASE_VERSIONS_DIR'/||g' \
     | egrep "/[0-9]+\.[0-9]+\.[0-9]+$" \
-    | sort -k 1 -k 2,2n -k 3,3n -t .
+    | sort -k 1,1 -k 2,2n -k 3,3n -t .
 }
 
 #


### PR DESCRIPTION
There is currently an issue where double-digit semver versions of node are listed in the wrong order:

```
$ n

io/3.3.1
node/0.12.12
node/4.4.0
node/5.10.0
node/5.2.0
node/5.6.0
node/5.7.0
node/5.8.0
node/5.9.0
node/5.9.1
```

Note that `node/5.10.0` is listed before `node/5.2.0`, when it should be placed at the end of the list.

This patch fixes this issue. With the patch, the version are sorted like this:

```
$ n

io/3.3.1
node/0.12.12
node/4.4.0
node/5.2.0
node/5.6.0
node/5.7.0
node/5.8.0
node/5.9.0
node/5.9.1
node/5.10.0
```