### PR TITLE
updated VERSION variable to 2.1.1 to mirror version in package.json

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -4,7 +4,7 @@
 # Setup.
 #
 
-VERSION="2.1.0"
+VERSION="2.1.3"
 UP=$'\033[A'
 DOWN=$'\033[B'
 N_PREFIX=${N_PREFIX-/usr/local}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n",
   "description": "Interactively Manage All Your Node Versions",
-  "version": "2.1.1",
+  "version": "2.1.3",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "homepage": "https://github.com/tj/n",
   "bugs": "https://github.com/tj/n/issues",


### PR DESCRIPTION
Posted an issue for this #361, entering n -V outputs a different version from package.json 