### PR TITLE
Persist global npm installs

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -487,14 +487,14 @@ activate() {
   if test "$version" != "$active"; then
     local old_dir=$BASE_VERSIONS_DIR/$active
     local dir=$BASE_VERSIONS_DIR/$version
+    if test -d "$N_PREFIX/lib/node_modules"; then
+      cp -fR "$N_PREFIX/lib/node_modules" "$old_dir/lib"
+    fi
     # Remove old npm to avoid potential issues with simple overwrite.
     if test -d "$dir/lib/node_modules/npm"; then
       if test -d "$N_PREFIX/lib/node_modules/npm"; then
         rm -rf "$N_PREFIX/lib/node_modules/npm"
       fi
-    fi
-    if test -d "$N_PREFIX/lib/node_modules"; then
-      cp -fR "$N_PREFIX/lib/node_modules" "$old_dir/lib"
     fi
     # Copy (lib before bin to avoid error messages on Darwin when cp over dangling link)
     for subdir in lib bin include share; do
@@ -801,3 +801,4 @@ else
     shift
   done
 fi
+

--- a/bin/n
+++ b/bin/n
@@ -485,12 +485,16 @@ activate() {
   local version=$1
   check_current_version
   if test "$version" != "$active"; then
+    local old_dir=$BASE_VERSIONS_DIR/$active
     local dir=$BASE_VERSIONS_DIR/$version
     # Remove old npm to avoid potential issues with simple overwrite.
     if test -d "$dir/lib/node_modules/npm"; then
       if test -d "$N_PREFIX/lib/node_modules/npm"; then
         rm -rf "$N_PREFIX/lib/node_modules/npm"
       fi
+    fi
+    if test -d "$N_PREFIX/lib/node_modules"; then
+      cp -fR "$N_PREFIX/lib/node_modules" "$old_dir/lib"
     fi
     # Copy (lib before bin to avoid error messages on Darwin when cp over dangling link)
     for subdir in lib bin include share; do

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,11 @@
+cd tests
+for f in $(ls *.sh); do
+    echo Running test... $f
+    bash $f
+    rc=$?
+    if [[ $rc -ne 0 ]]; then
+        echo TEST FAILED!
+        exit $rc
+    fi
+done
+cd ..

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,11 +1,31 @@
 cd tests
-for f in $(ls *.sh); do
-    echo Running test... $f
-    bash $f
+tests=$(ls -1 *.sh)
+tests=($tests)
+num_tests=${#tests[@]}
+declare -a failed_tests
+
+echo 1..$num_tests
+
+ct=1
+for f in ${tests[@]}; do
+    bash $f &> /dev/null
     rc=$?
     if [[ $rc -ne 0 ]]; then
-        echo TEST FAILED!
-        exit $rc
+        echo not ok $ct - ${f%.*}
+        failed_tests=( ${failed_tests[@]} $ct )
+    else
+        echo ok $ct - ${f%.*}
     fi
+    let ct=ct+1
 done
+
+num_failed=${#failed_tests[@]}
+if [[ $num_failed -gt 0 ]]; then
+    let num_okay="$num_tests - $num_failed"
+    pcnt_okay=$(bc -l <<< $num_okay/$num_tests*100)
+    echo FAILED tests ${failed_tests[@]}
+    printf "Failed $num_failed/$num_tests, %.2f%% okay\n" $pcnt_okay
+    exit 1
+fi
+exit 0
 cd ..

--- a/tests/test-new-npm-version-persists.sh
+++ b/tests/test-new-npm-version-persists.sh
@@ -20,3 +20,7 @@ echo Use 0.10.36
 $N 0.10.36
 
 test $($NPM --version) = "2.2.0"
+rc=$?
+
+rm -rf $N_PREFIX
+exit $rc

--- a/tests/test-new-npm-version-persists.sh
+++ b/tests/test-new-npm-version-persists.sh
@@ -1,0 +1,22 @@
+export N_PREFIX=/tmp/n
+export PATH=/tmp/n/bin:$PATH
+mkdir -p $N_PREFIX
+
+N=../bin/n
+NPM=/tmp/n/bin/npm
+
+$N latest
+
+echo Install 0.10.36
+$N 0.10.36
+
+echo Install different version of npm
+$NPM install -g npm@2.2
+
+echo Use latest
+$N latest
+
+echo Use 0.10.36
+$N 0.10.36
+
+test $($NPM --version) = "2.2.0"


### PR DESCRIPTION
Sometimes I need a different version of npm than the one installed with a version. Every time I switch node versions with n it wipes out my global node modules since it is a fresh copy from that installed version. This change backs up the global node modules so that the next time you switch to a previous version you were using the global node modules you installed will still be there.

run `./run_tests.sh` to demonstrate that this change fixes the problem.
