### PR TITLE
Add older Mac support to custom architecture section of the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ Download and use latest 32 bit version of `iojs`:
 
     $ n io --arch x86 latest
 
+Download and use 64 bit LTS version of `node` for older Mac Intel Core 2 Duo systems (x86 image is no longer available but x64 runs fine):
+
+    $ n --arch x64 lts
+
 ## Additional Details
 
 `n` installs versions to `/usr/local/n/versions` by default. Here, it can see what versions are currently installed and activate previously installed versions accordingly when `n <version>` is invoked again.


### PR DESCRIPTION
In response to @qw3rtman, I looked more closely at the potential for a pull request.  From the n perspective, you can actually load LTS (4.4.7) onto the older Intel Core 2 Duo systems (like my now ancient Mac Mini) with the custom architecture function.  It worked for me, and node 4.4.7 ran ok on the command line.  I updated the Readme file to reflect that.  Now, what people do with it is up to them.  