### PR TITLE
Resolve versions with no dots

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -500,7 +500,7 @@ install() {
   local version=${1#v}
 
   local dots=$(echo $version | sed 's/[^.]*//g')
-  if test ${#dots} -eq 1; then
+  if test ${#dots} -lt 2; then
     version=$($GET 2> /dev/null ${MIRROR[DEFAULT]} \
       | egrep "</a>" \
       | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' \


### PR DESCRIPTION
Before:

```
$ node -v
v4.5.0
$ n 6

     install : node-v6

  Error: invalid version 6

$ node -v
v4.5.0
```

After:

```
$ node -v
v4.5.0
$ n 6

     install : node-v6.5.0
       mkdir : /home/user/n/n/versions/node/6.5.0
       fetch : https://nodejs.org/dist/v6.5.0/node-v6.5.0-linux-x64.tar.gz
######################################################################## 100.0%
   installed : v6.5.0

$ node -v
v6.5.0
```
