### PR TITLE
Add pruning for non-active versions

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -167,6 +167,7 @@ display_help() {
     n use <version> [args ...]     Execute node <version> with [args ...]
     n bin <version>                Output bin path for <version>
     n rm <version ...>             Remove the given version(s)
+    n prune                        Remove all versions except the current version
     n --latest                     Output the latest node version available
     n --stable                     Output the latest stable node version available
     n --lts                        Output the latest LTS node version available
@@ -578,6 +579,14 @@ remove_versions() {
 }
 
 #
+# Prune non-active versions
+#
+
+prune() {
+    abort "not implemented"
+}
+
+#
 # Output bin path for <version>
 #
 
@@ -717,6 +726,7 @@ else
       as|use) shift; execute_with_version $@; exit ;;
       rm|-) shift; remove_versions $@; exit ;;
       latest) install_latest; exit ;;
+      prune) prune; exit ;;
       stable) install_stable; exit ;;
       lts) install_lts; exit ;;
       ls|list) display_remote_versions; exit ;;

--- a/bin/n
+++ b/bin/n
@@ -583,7 +583,15 @@ remove_versions() {
 #
 
 prune() {
-    abort "not implemented"
+  check_current_version
+  for version in $(versions_paths); do
+    if [ $version != $active ]
+    then
+      echo $version
+      rm -rf ${BASE_VERSIONS_DIR[$DEFAULT]}/$version
+      shift
+    fi
+  done
 }
 
 #


### PR DESCRIPTION
Add a basic prune command to remove all versions that aren't currently active.

```
n prune                        Remove all versions except the current version
```

Current output of running `n prune` with only `7.1.0`, `7.2.0` & `7.4.0` installed (with `7.4.0` being the active version):

```
$ n prune
node/7.1.0
node/7.2.0
```

Haven't extensively tested it yet but it seems to work well! Any feedback about output displayed back to the user or command syntax would be appreciated, but otherwise would love to get this implemented.

Kind of refs #404, but is not as feature complete as the suggestion. Additional functionality to the prune command could be easily added with CLI flags, such as `n prune --minor` or `n prune --all`.