### PR TITLE
Fix npmjs domain in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Flags also work here:
 After switching Node.js versions using `n`, `npm` may not work properly. This should fix it (thanks [@mikemoser](https://github.com/mikemoser)!):
 
 ```sh
-$ curl -0 -L https://npmjs.org/install.sh | sudo sh
+$ curl -0 -L https://npmjs.com/install.sh | sudo sh
 ```
 
 `sudo` may not be required depending on your system configuration.


### PR DESCRIPTION
Changed npm domain to npmjs.com from npmjs.org.

Failure
```
ubuntu@ubuntu17:~$ curl -0 -L https://npmjs.org/install.sh | sudo sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: npmjs.org
```

curl `npmjs.org`
```
ubuntu@ubuntu17:~$ curl npmjs.org -I
HTTP/1.1 301 Moved Permanently
Server: nginx/1.4.6 (Ubuntu)
Date: Sat, 11 Feb 2017 10:27:36 GMT
Content-Type: text/html
Content-Length: 193
Connection: keep-alive
Location: https://www.npmjs.com/
```

After `npmjs.org` => `npmjs.com`,  I get Succeed.
```
curl -0 -L https://npmjs.com/install.sh | sudo sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0   193    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  6263  100  6263    0     0   2932      0  0:00:02  0:00:02 --:--:--  764k
tar=/bin/tar
version:
...
...
...
```