### PR TITLE
Kill n's process group on sigint

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -4,7 +4,7 @@
 # Setup.
 #
 
-VERSION="2.1.6"
+VERSION="2.1.7"
 UP=$'\033[A'
 DOWN=$'\033[B'
 N_PREFIX=${N_PREFIX-/usr/local}

--- a/bin/n
+++ b/bin/n
@@ -134,7 +134,9 @@ leave_fullscreen() {
 
 handle_sigint() {
   leave_fullscreen
-  exit $?
+  S="$?"
+  kill 0
+  exit $S
 }
 
 handle_sigtstp() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n",
   "description": "Interactively Manage All Your Node Versions",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "homepage": "https://github.com/tj/n",
   "bugs": "https://github.com/tj/n/issues",


### PR DESCRIPTION
# Pull Request Template:

### Describe what you did
 _On sigint, kills n's process group, rather than only exiting with the parent's exit status_

### How you did it
Replaced `kill $?` with `kill 0`, which will [kill a process group](http://unix.stackexchange.com/a/67552/192793)
__

### How to verify it doesn't effect the functionality of n

It does effect n's functionality. Previously, bash would hang with the process group, and the terminal might not echo the input from STDIN. This kills all of those hanging processes and gives the user STDIN back.

### If this solves an issue, please put issue in PR notes.

This addresses issue #304 

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.



### Squash any unnecessary commits to keep history clean as possible

###  Place description for the changelog in PR so we can tally all changes for any future release
