### PR TITLE
Ignore broken certificates when using n over ssl proxy

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -54,6 +54,7 @@ fi
 #
 
 CURL_PARAMS=( "-L"
+              "--insecure"
               "-#")
 
 WGET_PARAMS=( "--no-check-certificate"


### PR DESCRIPTION
In wget there is already the "--no-check-certificate" option, but in curl it was missing. Added.

# Pull Request Template:

### Describe what you did
I added  an additional param for curl that ignores invalid ssl certificates. Otherwise, the download fails and leaves a broken install behind.

### How you did it
I tried to pull a newer version of node with `n latest`  through an ssl proxy. Curl was complaining that the certificate was not valid - which is true for SSL proxies a.k.a. MITM.

### How to verify it doesn't effect the functionality of n
Fetching updates with a "normal" environment works flawlessly.
