### PR TITLE
Adds vim-like keybindings to version selection

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -5,8 +5,6 @@
 #
 
 VERSION="2.1.7"
-UP=$'\033[A'
-DOWN=$'\033[B'
 N_PREFIX=${N_PREFIX-/usr/local}
 BASE_VERSIONS_DIR=$N_PREFIX/n/versions
 
@@ -330,20 +328,48 @@ display_versions() {
   trap handle_sigint INT
   trap handle_sigtstp SIGTSTP
 
+  ESCAPE_SEQ=$'\033'
+  UP=$'A'
+  DOWN=$'B'
+
   while true; do
-    read -n 3 c
-    case "$c" in
-      $UP)
+    read -rsn 1 key
+    case "$key" in
+      $ESCAPE_SEQ)
+        # Handle ESC sequences followed by other characters, i.e. arrow keys
+        read -rsn 1 -t 1 tmp
+        if  [[ "$tmp" == "[" ]]; then
+          read -rsn 1 -t 1 arrow
+          case "$arrow" in
+            $UP)
+              clear
+              display_versions_with_selected $(prev_version_installed)
+              ;;
+            $DOWN)
+              clear
+              display_versions_with_selected $(next_version_installed)
+              ;;
+          esac
+        fi
+        ;;
+      "k")
         clear
         display_versions_with_selected $(prev_version_installed)
         ;;
-      $DOWN)
+      "j")
         clear
         display_versions_with_selected $(next_version_installed)
         ;;
-      *)
+      "q")
+        clear
+        leave_fullscreen
+        exit
+        ;;
+      "")
+        # enter key returns empty string
         activate $selected
         leave_fullscreen
+        echo $selected
         exit
         ;;
     esac


### PR DESCRIPTION

# Pull Request Template:

### Describe what you did

- modifies switch statement to differentiate escape sequences from
  single key presses
- watches `j` and up arrow to move selection up
- watches `k` and down arrow to move selection down
- watches `q` to quit selection
- watches for enter to make selection
- disregards other keys

I didn't change the version number yet. Not sure if you wanted a minor version update or wait to merge for a major release.

### How you did it

Instead of using `read` to watch for three characters at a time, I'm watching for one character. Given a single key, like `j` or `k`, we can use a simple string comparison to determine the function to run. If that key is an ANSI escape code, we know that other characters will be incoming. For example, hitting the up arrow in a terminal sends `\033`, `[`, and `A`. So we can use another `read` for a single character with a timeout to cancel if nothing follows the escape. If this next character is a `[`, then it might be an arrow key. Use another single timed `read` to see which arrow it is and call the correct function.

### How to verify it doesn't effect the functionality of n

Run `n` and use arrow keys and `j`/`k` to test movement. Hit enter to select or `q` to quit. `Ctrl-C` still sends an interrupt as normal, but all other keys are disregarded.

### If this solves an issue, please put issue in PR notes.

Solves #411 as well as unreported issue with `n` hanging after one non-arrow key press because `read` was waiting for two more characters before continuing the script.
