### PR TITLE
Added support for arm64.

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -435,6 +435,8 @@ tarball_url() {
     *x86_64*) arch=x64 ;;
     *armv6l*) arch=armv6l ;;
     *armv7l*) arch=armv7l ;;
+    *arm64*) arch=arm64 ;;
+    *aarch64*) arch=arm64 ;;
   esac
 
   if [ ${arch} = "armv6l" -a ${BIN_NAME[$DEFAULT]} = node ]; then


### PR DESCRIPTION
I added support for the arm64 architecture.

This is already made available on nodejs.org. In the archives it is identified as _arm64_. I have seen it identified on systems as both _arm64_ and _aarch64_, so both are mapped to _arm64_ in my update.

