### PR TITLE
Fixed illegal char error in is_oss_ok function.

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -401,15 +401,15 @@ is_ok() {
 is_oss_ok() {
   if command -v curl > /dev/null; then
     if $GET -Is $1 | head -n 1 | grep 302 > /dev/null; then
-      is_oss_ok $GET -Is $1 | grep Location | awk -F ': ' '{print $2}'
+      is_oss_ok $($GET -Is $1 | grep Location | awk -F ': ' '{print $2}')
     else
-      $GET -Is $1 | head -n 1 | grep 200 > /dev/null
+      $GET -Is ${1%$'\r'} | head -n 1 | grep 200 > /dev/null
     fi
   else
     if $GET -S --spider 2>&1 $1 | head -n 1 | grep 302 > /dev/null; then
-      is_oss_ok $GET -S --spider 2>&1 $1 | grep Location | awk -F ': ' '{print $2}'
+      is_oss_ok $($GET -S --spider 2>&1 $1 | grep Location | awk -F ': ' '{print $2}')
     else
-      $GET -S --spider 2>&1 $1 | head -n 1 | grep 200 > /dev/null
+      $GET -S --spider 2>&1 ${1%$'\r'} | head -n 1 | grep 200 > /dev/null
     fi
   fi
 }


### PR DESCRIPTION
### Describe question
When set `NODE_MIRROR` to `https://npm.taobao.org/mirrors/node/`, the `n` will get an oss link to download `node`. There are two errors.

Line:404-This line will pass the `curl` (the value of `$GET` ) in `is_oss_link`.
Line:406-The `curl` can't accept a URL contains `\r`.
Line:410-This line will pass the `wget` (the value of `$GET` ) in `is_oss_link`.
Line:412-This line is fine.

### What my code do
Line:404&410-Use command substitution.
Line:406&412-Remove the illegal character `\r` .

### System environment
OS: Ubuntu 12.04 lts 64bit
n: version 2.1.8
```
curl version and bash version

curl 7.22.0 (x86_64-pc-linux-gnu) libcurl/7.22.0 OpenSSL/1.0.1 zlib/1.2.3.4 libidn/1.23 librtmp/2.3
Protocols: dict file ftp ftps gopher http https imap imaps ldap pop3 pop3s rtmp rtsp smtp smtps telnet tftp 
Features: GSS-Negotiate IDN IPv6 Largefile NTLM NTLM_WB SSL libz TLS-SRP

GNU bash, version 4.2.25(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2011 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```
