### PR TITLE
Add `lsi` and `installed` options to list installed versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,11 @@ Output can also be obtained from `n --help`.
 
     Aliases:
 
-      which   bin
-      use     as
-      list    ls
-      -       rm
+      which      bin
+      use        as
+      list       ls
+      installed  lsi
+      -          rm
 
 ## Custom source
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Simply execute `n <version>` to install a version of `node`. If `<version` has a
     $ n 0.9.6
 
 Execute `n` on its own to view your currently installed versions. Use the up and down arrow keys to navigate and press enter or the right arrow key to select. Use ^C (control + C) to exit the selection screen.
-If you like vim key bindings during the selection of node versions, you can use `j` and `k` to navigate up or down without using arrows. 
+If you like vim key bindings during the selection of node versions, you can use `j` and `k` to navigate up or down without using arrows.
 
     $ n
 
@@ -80,7 +80,7 @@ Alternatively, you can use `-` in lieu of `rm`:
 Removing all versions except the current version:
 
 ```bash
-$ n prune 
+$ n prune
 ```
 
 ### Binary Usage
@@ -135,6 +135,7 @@ Output can also be obtained from `n --help`.
       n --stable                     Output the latest stable node version available
       n --lts                        Output the latest LTS node version available
       n ls                           Output the versions of node available
+      n lsi                          Output installed versions of node and iojs
 
     (iojs):
 

--- a/bin/n
+++ b/bin/n
@@ -783,7 +783,7 @@ else
       stable) install_stable; exit ;;
       lts) install_lts; exit ;;
       ls|list) display_remote_versions; exit ;;
-      lsi) list_versions_installed; exit ;;
+      lsi|installed) list_versions_installed; exit ;;
       *) install $1; exit ;;
     esac
     shift

--- a/bin/n
+++ b/bin/n
@@ -737,6 +737,33 @@ display_remote_versions() {
 }
 
 #
+# Display the versions locally downloaded.
+#
+
+display_local_versions() {
+  check_current_version
+
+  local versions="$(list_versions_installed)"
+
+  for v in $versions; do
+    # split string into binary/version parts
+	version_parts=(${v//\// })
+	bin="${version_parts[0]}"
+	version="${version_parts[1]}"
+
+	if test "$active" = "$v"; then
+      printf "  \033[36mο\033[0m $version \033[0m\n"
+    else
+      if test -d $BASE_VERSIONS_DIR/$bin/$version; then
+        printf "    $version \033[0m\n"
+      else
+        printf "    \e[2m$version\e[22m\n"
+      fi
+    fi
+  done
+}
+
+#
 # Handle arguments.
 #
 
@@ -763,7 +790,7 @@ else
       stable) install_stable; exit ;;
       lts) install_lts; exit ;;
       ls|list) display_remote_versions; exit ;;
-      lsi|installed) list_versions_installed; exit ;;
+      lsi|installed) display_local_versions; exit ;;
       *) install $1; exit ;;
     esac
     shift

--- a/bin/n
+++ b/bin/n
@@ -783,6 +783,7 @@ else
       stable) install_stable; exit ;;
       lts) install_lts; exit ;;
       ls|list) display_remote_versions; exit ;;
+      lsi) list_versions_installed; exit ;;
       *) install $1; exit ;;
     esac
     shift


### PR DESCRIPTION
### Describe what you did
Add new options to list installed node/iojs versions:

`n lsi`
`n installed`

**Questions**

- Should these have different names?
- Alternatively, should this instead be a flag on the `ls` option?
  * I was going to add this as a flag to `ls` originally, but `ls` only lists node or iojs where this should probably list everything installed.

### How you did it

Function already existed.  It was just added it to the options loop.

### How to verify it doesn't effect the functionality of n

The function was already there.  The only change was to the options.  It would just keep users from installing versions named "installed" or "lsi".