### PR TITLE
Effectively make stable an alias for lts. (Solves issue #335)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Simply execute `n <version>` to install a version of `node`. If `<version>` has 
     $ n 0.9.6
 
 Execute `n` on its own to view your currently installed versions. Use the up and down arrow keys to navigate and press enter to select. Use `q` or ^C (control + C) to exit the selection screen.
-If you like vim key bindings during the selection of node versions, you can use `j` and `k` to navigate up or down without using arrows. 
+If you like vim key bindings during the selection of node versions, you can use `j` and `k` to navigate up or down without using arrows.
 
     $ n
 
@@ -58,10 +58,6 @@ If you like vim key bindings during the selection of node versions, you can use 
 Use or install the latest official release:
 
     $ n latest
-
-Use or install the stable official release:
-
-    $ n stable
 
 Use or install the latest LTS official release:
 
@@ -80,7 +76,7 @@ Alternatively, you can use `-` in lieu of `rm`:
 Removing all versions except the current version:
 
 ```bash
-$ n prune 
+$ n prune
 ```
 
 ### Binary Usage
@@ -124,7 +120,6 @@ Output can also be obtained from `n --help`.
       n                              Output versions installed
       n latest                       Install or activate the latest node release
       n -a x86 latest                As above but force 32 bit architecture
-      n stable                       Install or activate the latest stable node release
       n lts                          Install or activate the latest LTS node release
       n <version>                    Install node <version>
       n use <version> [args ...]     Execute node <version> with [args ...]
@@ -132,7 +127,6 @@ Output can also be obtained from `n --help`.
       n rm <version ...>             Remove the given version(s)
       n prune                        Remove all versions except the current version
       n --latest                     Output the latest node version available
-      n --stable                     Output the latest stable node version available
       n --lts                        Output the latest LTS node version available
       n ls                           Output the versions of node available
 
@@ -161,6 +155,7 @@ Output can also be obtained from `n --help`.
       use     as
       list    ls
       -       rm
+      stable  lts
 
 ## Custom source
 

--- a/bin/n
+++ b/bin/n
@@ -161,7 +161,6 @@ display_help() {
     n                              Output versions installed
     n latest                       Install or activate the latest node release
     n -a x86 latest                As above but force 32 bit architecture
-    n stable                       Install or activate the latest stable node release
     n lts                          Install or activate the latest LTS node release
     n <version>                    Install node <version>
     n use <version> [args ...]     Execute node <version> with [args ...]
@@ -169,7 +168,6 @@ display_help() {
     n rm <version ...>             Remove the given version(s)
     n prune                        Remove all versions except the current version
     n --latest                     Output the latest node version available
-    n --stable                     Output the latest stable node version available
     n --lts                        Output the latest LTS node version available
     n ls                           Output the versions of node available
 
@@ -197,6 +195,7 @@ display_help() {
     use     as
     list    ls
     -       rm
+    stable  lts
 
 EOF
 }
@@ -514,6 +513,7 @@ install_latest() {
 
 #
 # Install latest stable version.
+# (See additional comments for display_latest_stable_version)
 #
 
 install_stable() {
@@ -706,15 +706,16 @@ display_latest_version() {
 
 #
 # Display the latest stable release version.
+# Note: Stable is no longer used by nodejs to identify versions,
+# so this could be considered deprecated. To avoid breaking
+# existing usages and minimise code churn in meantime,
+# return the lts version.
+# lts is the version recommended for most users.
 #
 
 display_latest_stable_version() {
   check_io_supported "--stable"
-  $GET 2> /dev/null ${MIRROR[$DEFAULT]} \
-    | egrep "</a>" \
-    | egrep -o '[0-9]+\.[0-9]*[02468]\.[0-9]+' \
-    | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
-    | tail -n1
+  display_latest_lts_version
 }
 
 #


### PR DESCRIPTION
# Pull Request Template:

### Describe what you did

Made stable an alias for lts.

### How you did it

Removed stable from documented options, other than as an alias for lts.
Modified display_latest_stable_version to return LTS version.
Retained existing stable code for backwards compatibility. 

### How to verify it doesn't effect the functionality of n

n --latest: 8.8.1
n --lts: 6.11.5
n --stable: 6.11.5
n latest && node --version: v8.8.1
n stable && node --version: v6.11.5
n latest && node --version: v8.8.1
n lts && node --version: v6.11.5

### If this solves an issue, please put issue in PR notes.

Solves issue #335 where stable was using old pattern of latest even minor version number.

Using lts is a good match for "stable", but is a significant change to the erroneous behaviour which was sometimes same as latest .

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.

Say node latest was at 8.9.2.

Old:
n --latest: 8.9.2
n --lts: 6.11.5
n --stable: 8.8.1

New:
n --latest: 8.9.2
n --lts: 6.11.5
n --stable:  6.11.5

### Squash any unnecessary commits to keep history clean as possible

###  Place description for the changelog in PR so we can tally all changes for any future release

Change stable to be an alias for lts.

