### PR TITLE
Remove existing npm folder before copying activated version

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -484,7 +484,14 @@ activate() {
   check_current_version
   if test "$version" != "$active"; then
     local dir=$BASE_VERSIONS_DIR/$version
-    for subdir in bin lib include share; do
+    # Remove old npm to avoid potential issues with simple overwrite.
+    if test -d "$dir/lib/node_modules/npm"; then
+      if test -d "$N_PREFIX/lib/node_modules/npm"; then
+        rm -rf "$N_PREFIX/lib/node_modules/npm"
+      fi
+    fi
+    # Copy (lib before bin to avoid error messages on Darwin when cp over dangling link)
+    for subdir in lib bin include share; do
       if test -L "$N_PREFIX/$subdir"; then
         find "$dir/$subdir" -mindepth 1 -maxdepth 1 -exec cp -fR "{}" "$N_PREFIX/$subdir" \;
       else


### PR DESCRIPTION
# Pull Request Template:

### Describe what you did

Improve robustness of install of npm included with node (over a previous install).

### How you did it

Delete previous npm install folder.

### How to verify it doesn't effect the functionality of n

node and npm still functional after activating node versions, issues addressed.

### If this solves an issue, please put issue in PR notes.

Issue #440
Issue #453
Issue #462
(And probably issues #206, #236, #403)

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.

Notes on reproduce steps:
- assuming default install location for initial rm -rf
- add sudo if required
- cp warnings are a Darwin issue which is also improved
- the forest-arborist install is to show that global modules are not deleted, not otherwise significant


Issue #440. Checked on macOS High Sierra and Debian Jessie.

Before
$ rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/node
$ n 6.11.5
cp: symlink: ../lib/node_modules/npm/bin/npm-cli.js: File exists
$ npm install --global @shadowspawn/forest-arborist
$ n 8.8.1
cp: symlink: ../lib/node_modules/npm/bin/npx-cli.js: File exists
$ npm list --global --depth=0
/usr/local/lib
├── @shadowspawn/forest-arborist@1.0.1
└── npm@5.4.2

npm ERR! missing: npm-package-arg@^4.1.1, required by realize-package-specifier@3.0.3
npm ERR! invalid: glob@6.0.4 /usr/local/lib/node_modules/npm/node_modules/init-package-json/node_modules/glob
npm ERR! missing: strip-ansi@^3.0.1, required by gauge@2.6.0
npm ERR! missing: strip-ansi@^3.0.0, required by string-width@1.0.2
npm ERR! invalid: readable-stream@2.0.6 /usr/local/lib/node_modules/npm/node_modules/npm-registry-client/node_modules/concat-stream/node_modules/readable-stream
npm ERR! missing: strip-ansi@^3.0.1, required by gauge@2.6.0
npm ERR! missing: strip-ansi@^3.0.0, required by string-width@1.0.2
npm ERR! invalid: glob@6.0.4 /usr/local/lib/node_modules/npm/node_modules/read-package-json/node_modules/glob
npm ERR! missing: strip-ansi@^3.0.0, required by chalk@1.1.3

After
$ rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/node
$ n 6.11.5
$ npm install --global @shadowspawn/forest-arborist
$ n 8.8.1
$ npm list --global --depth=0
/usr/local/lib
├── @shadowspawn/forest-arborist@1.0.1
└── npm@5.4.2


Issue #453. Checked on macOS High Sierra and Debian Jessie.

Before
$ rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/node
$ n 4.1.2
cp: symlink: ../lib/node_modules/npm/bin/npm-cli.js: File exists
$ n 8.2.1
cp: symlink: ../lib/node_modules/npm/bin/npx-cli.js: File exists
$ npm doctor
npm ERR! code MODULE_NOT_FOUND
npm ERR! Cannot find module 'internal/fs'

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/john/.npm/_logs/2017-10-29T00_49_59_380Z-debug.log

After
$ rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/node
$ n 4.1.2
$ n 8.2.1
$ npm doctor
npm WARN verifyCachedFiles Content garbage-collected: 3 (87960 bytes)
npm WARN verifyCachedFiles Cache issues have been fixed
Check                               Value                        Recommendation
npm ping                            OK
npm -v                              v5.3.0                       Use npm v5.5.1
node -v                             v8.2.1
npm config get registry             https://registry.npmjs.org/
which git                           /usr/bin/git
Perms check on cached files         ok
Perms check on global node_modules  ok
Perms check on local node_modules   ok
Verify cache contents               verified 1345 tarballs


Issue #462

Before
$ rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/node
$ n 5.0.0
cp: symlink: ../lib/node_modules/npm/bin/npm-cli.js: File exists
$ n 7.0.0
$ npm install
npm ERR! Darwin 17.0.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install"
npm ERR! node v7.0.0
npm ERR! npm  v3.10.8
npm ERR! code MODULE_NOT_FOUND

npm ERR! Cannot find module 'internal/fs'
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/john/Documents/Sandpits/ReproduceTemp/npm-debug.log

After (expected error running npm install in empty directory)
$ rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/node
$ n 5.0.0
$ n 7.0.0
$ npm install
npm WARN enoent ENOENT: no such file or directory, open '/Users/john/Documents/Sandpits/ReproduceTemp/package.json'
npm WARN ReproduceTemp No description
npm WARN ReproduceTemp No repository field.
npm WARN ReproduceTemp No README data
npm WARN ReproduceTemp No license field.


Issues #206, #236, #403

Likely to address the described issue by removing previous npm install folder before copy, but unable to reproduce the original problem using the described steps so not confirmed.


### Squash any unnecessary commits to keep history clean as possible

###  Place description for the changelog in PR so we can tally all changes for any future release

Delete old npm folder before copying new folder.
