### PR TITLE
Fix OSS check

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -385,32 +385,20 @@ erase_line() {
 }
 
 #
-# Check if the HEAD response of <url> is 200.
-#
-is_ok() {
-  if command -v curl > /dev/null; then
-    $GET -Is $1 | head -n 1 | grep 200 > /dev/null
-  else
-    $GET -S --spider 2>&1 $1 | head -n 1 | grep 200 > /dev/null
-  fi
-}
-
-#
 # Check if the OSS(Object Storage Service) mirror is ok.
 #
 is_oss_ok() {
+  local headers=
   if command -v curl > /dev/null; then
-    if $GET -Is $1 | head -n 1 | grep 302 > /dev/null; then
-      is_oss_ok `$GET -Is $1 | grep Location | sed -Ee 's/Location: (.+\.tar\.gz).*$/\1/'`
-    else
-      $GET -Is $1 | head -n 1 | grep 200 > /dev/null
-    fi
+    headers=`$GET -Is $1`
   else
-    if $GET -S --spider 2>&1 $1 | head -n 1 | grep 302 > /dev/null; then
-      is_oss_ok `$GET -S --spider 2>&1 $1 | grep Location | sed -Ee 's/Location: (.+\.tar\.gz).*$/\1/'`
-    else
-      $GET -S --spider 2>&1 $1 | head -n 1 | grep 200 > /dev/null
-    fi
+    headers=`$GET -S --spider 2>&1 $1`
+  fi
+
+  if echo "$headers" | head -n 1 | grep 302 > /dev/null; then
+    is_oss_ok `echo "$headers" | grep Location | sed -Ee 's/^Location: (.+\.tar\.gz).*$/\1/'`
+  else
+    echo "$headers" | head -n 1 | grep 200 > /dev/null
   fi
 }
 
@@ -557,7 +545,7 @@ install() {
   log install ${BINS[$DEFAULT]}-v$version
 
   local url=$(tarball_url $version)
-  is_ok $url || is_oss_ok $url || abort "invalid version $version"
+  is_oss_ok $url || abort "invalid version $version"
 
   log mkdir $dir
   mkdir -p $dir

--- a/bin/n
+++ b/bin/n
@@ -401,13 +401,13 @@ is_ok() {
 is_oss_ok() {
   if command -v curl > /dev/null; then
     if $GET -Is $1 | head -n 1 | grep 302 > /dev/null; then
-      is_oss_ok $GET -Is $1 | grep Location | awk -F ': ' '{print $2}'
+      is_oss_ok `$GET -Is $1 | grep Location | sed -Ee 's/Location: (.+\.tar\.gz).*$/\1/'`
     else
       $GET -Is $1 | head -n 1 | grep 200 > /dev/null
     fi
   else
     if $GET -S --spider 2>&1 $1 | head -n 1 | grep 302 > /dev/null; then
-      is_oss_ok $GET -S --spider 2>&1 $1 | grep Location | awk -F ': ' '{print $2}'
+      is_oss_ok `$GET -S --spider 2>&1 $1 | grep Location | sed -Ee 's/Location: (.+\.tar\.gz).*$/\1/'`
     else
       $GET -S --spider 2>&1 $1 | head -n 1 | grep 200 > /dev/null
     fi


### PR DESCRIPTION
# Pull Request Template:

### Describe what you did
Fix function `is_oss_ok`.
  - the recursive call should use the whole rest part as an argument
  - the `awk` picks the wrong location with `\r` at the end

### How you did it
Fixed by,
  - wrap the rest by backticks
  - replace `awk` with `sed`

### How to verify it doesn't effect the functionality of n
NODE_MIRROR=https://npm.taobao.org/mirrors/node/ n 8.9.0

### If this solves an issue, please put issue in PR notes.
- Solved #314.
- #318 tried to fix but failed, and #460 is not the best way.

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.
- Before
```
[zhong@localhost n]$ NODE_MIRROR=https://npm.taobao.org/mirrors/node/ n 8.9.0

     install : node-v8.9.0

  Error: invalid version 8.9.0
```
- After (Very quickly in China! But the official nodejs.org is slow due to network censorship.)
```
[zhong@localhost n]$ NODE_MIRROR=https://npm.taobao.org/mirrors/node/ n 8.9.0

     install : node-v8.9.0
       mkdir : /usr/local/n/versions/node/8.9.0
       fetch : https://npm.taobao.org/mirrors/node/v8.9.0/node-v8.9.0-darwin-x64.tar.gz
######################################################################## 100.0%
   installed : v8.9.0
```

### Squash any unnecessary commits to keep history clean as possible
Only 1 commit.

###  Place description for the changelog in PR so we can tally all changes for any future release
Fix OSS check then able to download from special mirror sites.