### PR TITLE
add colons to reduce ambiguity

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -539,7 +539,7 @@ install() {
       | egrep ^$version \
       | tail -n1)
 
-    test $version || abort "invalid version ${1#v}"
+    test $version || abort "invalid version: ${1#v}"
   fi
 
   local dir=${VERSIONS_DIR[$DEFAULT]}/$version
@@ -557,7 +557,7 @@ install() {
   log install ${BINS[$DEFAULT]}-v$version
 
   local url=$(tarball_url $version)
-  is_ok $url || is_oss_ok $url || abort "invalid version $version"
+  is_ok $url || is_oss_ok $url || abort "invalid version: $version"
 
   log mkdir $dir
   mkdir -p $dir


### PR DESCRIPTION
# Pull Request Template:

### Describe what you did

Reduced ambiguity in an error message. A friend was having trouble as he typed "n install stable" rather than "n stable". An error message with a colon would have immediately indicated what was wrong, but the current message made him think that the version was incorrect. Note that adding "install" is the syntax in nvm, so people transitioning might be confused by this.

example:

`Error: invalid version install`

vs

`Error: invalid version: install`

### How you did it

Added a colon to it.

### How to verify it doesn't effect the functionality of n

The change is trivial, but can be verified by simply running the string with the abort function in a separate script.

###  Place description for the changelog in PR so we can tally all changes for any future release
