### PR TITLE
warn user when current node is not found under n/versions

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -208,6 +208,15 @@ err_no_installed_print_help() {
 }
 
 #
+# Warn user that current node is not managed by n.
+#
+
+warn_current_node_not_managed_by_n() {
+  printf "\n  \033[33mWarning: the current node binary could not be found among the versions installed by n. Make sure you add \$N_PREFIX/bin to PATH before other entries poiting to directories containing node binaries. This can also happen if you are using a \$PROJECT_VERSION_CHECK and it returns a different version than the one the current selected version was installed as (e.g. the current version is not a custom project version or \$PROJECT_VERSION_CHECK has changed since its installation).\033[0m\n\n"
+  read -rp "  Press ENTER to select a new version (selection will fallback to the first available version)"
+}
+
+#
 # Hide cursor.
 #
 
@@ -266,6 +275,10 @@ check_current_version() {
         active=$bin/$current
       fi
     done
+  fi
+  if test -z "$active"; then
+    warn_current_node_not_managed_by_n
+    active="$(list_versions_installed | head -n 1)"
   fi
 }
 


### PR DESCRIPTION
### Describe what you did
Added a warning and made the first available node binary the default selection when the current node (as returned by `which node`) is not found under `n/versions`.
 
### How you did it

I modified the function that tries to figure out the current selected node version to warn the user and default to the first available version when it's not found under the directory used by n to store its node binaries.

I saw two possibilities for that to happen, and tried to made the warning be helpful about them:

- The user does not have `$N_PREFIX/bin` in `$PATH`, or has an earlier entry that gets picked first.
- The user has set `PROJECT_VERSION_CHECK` but it's not compatible with the current select node (either because he changed its value after installing or the current node version is not even a custom version).

### How to verify it doesn't effect the functionality of n

Currently, when the situation described above happens, the user sees grep's error message, as it is called with an invalid argument as a result of the current version being an empty string. Now, the user will see a warning, and will be expected to press enter. So, it will effect functionality, but I guess that's better than what we have right now.

I choose to let them proceed despite knowing they would still need to fix things later because I guessed in the case where the problem is their `PROJECT_VERSION_CHECK` they could still just want to use another version and deal with that later. 

### If this solves an issue, please put issue in PR notes.

I couldn't find one, but I guess it's the same thing people were complaining about [here](https://github.com/tj/n/issues/400).

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.

Before:

```
Usage: grep [OPTION]... PATTERN [FILE]...
Try 'grep --help' for more information.

    node/8.4.0
    node/9.5.0
```

Now:

```
  Warning: the current node binary could not be found among the versions installed by n. Make sure you add $N_PREFIX/bin to PATH before other entries poiting to directories containing node binaries. This can also happen if you are using a $PROJECT_VERSION_CHECK and it returns a different version than the one the current selected version was installed as (e.g. the current version is not a custom project version or $PROJECT_VERSION_CHECK has changed since its installation).

  Press ENTER to select a new version (selection will fallback to the first available version)
```

The warning is colored, like other messages are in n. Notice this is called after `enter_fullscreen`, which have two side effects:

- The message is showed at the bottom of the screen (that can be solved with another `clear`, I just thought there was no need).
- The warning is cleared when the user leaves full screen mode, so after exiting, only the version selected is showed, exactly how it was before.

### Squash any unnecessary commits to keep history clean as possible

:+1: 

###  Place description for the changelog in PR so we can tally all changes for any future release

Added warning when current selected node version (as reported by `which node`) is not found under `n/versions`.