### PR TITLE
Detect arm64 architecture

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -435,6 +435,7 @@ tarball_url() {
     *x86_64*) arch=x64 ;;
     *armv6l*) arch=armv6l ;;
     *armv7l*) arch=armv7l ;;
+    *aarch64*) arch=arm64 ;;
   esac
 
   if [ ${arch} = "armv6l" -a ${BIN_NAME[$DEFAULT]} = node ]; then


### PR DESCRIPTION
### Describe what you did
Added `arm64` architecture compatibility.

### How you did it
Added an entry for the "arm64" architecture to the architecture `uname` case statement in `tarball_url()`. Actually, the string to look for in the `uname` output is `aarch64`, but on the nodejs site that architecture is called "arm64".

### How to verify it doesn't effect the functionality of n
```bash
$ uname -a
```
On any machine on which the output of `uname` does *not* contain the string "aarch64", this PR will have no effect.

### If this solves an issue, please put issue in PR notes.
I never filed an issue for this.

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.
If your machine is on this architecture (e.g. a Samsung Chromebook Plus), it previously would have worked like this:
```bash
$ sudo n latest

     install : node-v9.9.0
       mkdir : /usr/local/n/versions/node/9.9.0
       fetch : https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-x86.tar.gz
######################################################################## 100.0%
/usr/local/bin/n: line 582: /usr/local/bin/node: cannot execute binary file: Exec format error
   installed : 
$ node --version
-su: /usr/local/bin/node: cannot execute binary file: Exec format error
```
After this change, it's more like this:
```bash
$ sudo n latest

     install : node-v9.9.0
       mkdir : /usr/local/n/versions/node/9.9.0
       fetch : https://nodejs.org/dist/v9.9.0/node-v9.9.0-linux-arm64.tar.gz
######################################################################## 100.0%
   installed : v9.9.0

$ node --version
v9.9.0
```

### Squash any unnecessary commits to keep history clean as possible

###  Place description for the changelog in PR so we can tally all changes for any future release
"add detection for **arm64**/**aarch64** architecture"