### PR TITLE
Fix order with node/10.0.0 tj/n#497

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -285,7 +285,7 @@ versions_paths() {
   find $BASE_VERSIONS_DIR -maxdepth 2 -type d \
     | sed 's|'$BASE_VERSIONS_DIR'/||g' \
     | egrep "/[0-9]+\.[0-9]+\.[0-9]+$" \
-    | sort -k 1,1 -k 2,2n -k 3,3n -t .
+    | sort -k 1,1 -k 2,2n -t /
 }
 
 #


### PR DESCRIPTION
### Describe what you did
Change the sort logic when displaying installed versions. (Command `n`)

### How you did it
Example of a line: `node/8.5.0`
To do the sort, we were splitting the line on `.` characters, which would give [ 'node/8', '5', '0' ]
Then applying an alphabetical order on the first term, and a numeric order on the two next terms.
But it doesn't give the expected result when having `node/10.0.0`, as `node/10` is considered less than `node/8` when applying an alphabetical order.
I now split the line on `/` character, which gives [ 'node', '8.5.0' ], applying an alphabetical order on the first term and a numeric order on the second term.

### How to verify it doesn't affect the functionality of n
Try `n` command with a few different versions of io / node installed and check that the order is as expected.

### If this solves an issue, please put issue in PR notes.
solves issue #497 

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.

Previously:
```
io/3.3.1
node/0.12.18
node/10.0.0
node/6.11.0
node/6.13.0
node/7.10.1
node/8.5.0
node/9.2.0
node/9.2.1
node/9.5.0
node/9.9.0
```

After fix:
```
io/3.3.1
node/0.12.18
node/6.11.0
node/6.13.0
node/7.10.1
node/8.5.0
node/9.2.0
node/9.2.1
node/9.5.0
node/9.9.0
node/10.0.0
```

###  Place description for the changelog in PR so we can tally all changes for any future release

Versions 10 or greater are now displayed as expected at the end of the list of installed versions
