### PR TITLE
Don't clear scrollback history in `display_versions`

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -322,7 +322,7 @@ list_versions_installed() {
 display_versions() {
   enter_fullscreen
   check_current_version
-  clear
+  tput clear
   display_versions_with_selected $active
 
   trap handle_sigint INT
@@ -342,26 +342,26 @@ display_versions() {
           read -rsn 1 -t 1 arrow
           case "$arrow" in
             $UP)
-              clear
+              tput clear
               display_versions_with_selected $(prev_version_installed)
               ;;
             $DOWN)
-              clear
+              tput clear
               display_versions_with_selected $(next_version_installed)
               ;;
           esac
         fi
         ;;
       "k")
-        clear
+        tput clear
         display_versions_with_selected $(prev_version_installed)
         ;;
       "j")
-        clear
+        tput clear
         display_versions_with_selected $(next_version_installed)
         ;;
       "q")
-        clear
+        tput clear
         leave_fullscreen
         exit
         ;;


### PR DESCRIPTION
Currently, n clears scrollback history in the `display_versions` function because it calls `clear`. (The fact that we're in fullscreen mode at the time apparently doesn't matter.) This PR replaces calls to `clear` with calls to `tput clear`, which only clears the visible screen, not the scrollback history.

The changes are trivial and `tput` is already known to exist by the time we run `tput clear` (because of the prior call to `tput smcup`), so this shouldn't affect existing functionality.