### PR TITLE
Go back to plain numeric sorting for older versions of sort

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -285,7 +285,9 @@ versions_paths() {
   find $BASE_VERSIONS_DIR -maxdepth 2 -type d \
     | sed 's|'$BASE_VERSIONS_DIR'/||g' \
     | egrep "/[0-9]+\.[0-9]+\.[0-9]+$" \
-    | sort -k 1,1 -k 2,2V -t /
+    | sed 's|/|.|' \
+    | sort -k 1,1 -k 2,2n -k 3,3n -k 4,4n -t . \
+    | sed 's|\.|/|'
 }
 
 #


### PR DESCRIPTION
# Pull Request Template:

### Describe what you did

Replaced introduced sort flags not supported in older versions of sort.

### How you did it

Used sed to make the prefix (node/) into a key (node.) so number parts can be sorted using (old) numeric sort, then restore prefix.

### How to verify it doesn't effect the functionality of n

n listing now works on macOS Sierra 10.12.6, still works on macOS High Sierra 10.13.4.

### If this solves an issue, please put issue in PR notes.

Solves issue #502

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.



### Squash any unnecessary commits to keep history clean as possible

###  Place description for the changelog in PR so we can tally all changes for any future release

Fix n interactive list to still work with older versions of sort (and still put node 10 after node 9).