### PR TITLE
Don't skip cert check when using wget

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -54,8 +54,7 @@ fi
 CURL_PARAMS=( "-L"
               "-#")
 
-WGET_PARAMS=( "--no-check-certificate"
-              "-q"
+WGET_PARAMS=( "-q"
               "-O-")
 
 if [ -n "$HTTP_USER" ];then


### PR DESCRIPTION
Curl checks TLS cert validity. Wget ought to do the same.