### PR TITLE
Fix n lts incorrect version

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -732,7 +732,8 @@ display_latest_lts_version() {
   $GET 2> /dev/null ${MIRROR[$DEFAULT]}/$folder_name/ \
     | egrep "</a>" \
     | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' \
-    | head -n1
+    | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
+    | tail -n1
 }
 
 #


### PR DESCRIPTION
I could not install latest LTS version with `n lts` command:
```bash
$ n --lts
8.10.0
```
With this patch:
```bash
$ n --lts
8.11.3
```
I just sort and tail like `display_latest_version` and `display_latest_stable_version`.
