### PR TITLE
Add support for release stream codenames to install, bin, and use

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ Use or install the latest LTS official release:
 
     $ n lts
 
+Use or install release streams by codename:
+
+    $ n carbon
+
+Install release stream by partial number:
+
+    $ n 8
+    $ n 6.14
+
 ### Removing Versions
 
 Remove some versions:

--- a/bin/n
+++ b/bin/n
@@ -535,7 +535,13 @@ install_lts() {
 #
 
 install() {
-  local version=${1#v}
+  local version=
+  if [[ "$1" =~ [a-z]{2,} ]]; then
+    version=$(display_latest_codename_version $1)
+    test $version || abort "invalid version $1"
+  else
+    version=${1#v}
+  fi
 
   local dots=$(echo $version | sed 's/[^.]*//g')
   if test ${#dots} -lt 2; then
@@ -637,25 +643,26 @@ prune_versions() {
 
 display_bin_path_for_version() {
   test -z $1 && abort "version required"
-  local version=${1#v}
+  local version=$1
 
   if [ "$version" = "latest" ]; then
     version=$(display_latest_version)
-  fi
-
-  if [ "$version" = "stable" ]; then
+  elif [ "$version" = "stable" ]; then
     version=$(display_latest_stable_version)
-  fi
-
-  if [ "$version" = "lts" ]; then
+  elif [ "$version" = "lts" ]; then
     version=$(display_latest_lts_version)
+  elif [[ "$version" =~ [a-z]{2,} ]]; then
+    version=$(display_latest_codename_version $version)
+    test $version || abort "invalid codename $version"
+  else
+    local version=${1#v}
   fi
 
   local bin=${VERSIONS_DIR[$DEFAULT]}/$version/bin/node
   if test -f $bin; then
     printf "$bin \n"
   else
-    abort "$1 is not installed"
+    abort "$version is not installed"
   fi
 }
 
@@ -665,18 +672,19 @@ display_bin_path_for_version() {
 
 execute_with_version() {
   test -z $1 && abort "version required"
-  local version=${1#v}
+  local version=$1
 
   if [ "$version" = "latest" ]; then
     version=$(display_latest_version)
-  fi
-
-  if [ "$version" = "stable" ]; then
+  elif [ "$version" = "stable" ]; then
     version=$(display_latest_stable_version)
-  fi
-
-  if [ "$version" = "lts" ]; then
+  elif [ "$version" = "lts" ]; then
     version=$(display_latest_lts_version)
+  elif [[ "$version" =~ [a-z]{2,} ]]; then
+    version=$(display_latest_codename_version $version)
+    test $version || abort "invalid codename $version"
+  else
+    version=${1#v}
   fi
 
   local bin=${VERSIONS_DIR[$DEFAULT]}/$version/bin/node
@@ -688,6 +696,25 @@ execute_with_version() {
   else
     abort "$version is not installed"
   fi
+}
+
+#
+# Display codename version.
+#
+
+display_latest_codename_version() {
+  local folder_name=$($GET 2> /dev/null ${MIRROR[$DEFAULT]} \
+    | egrep "</a>" \
+    | egrep -o "latest-$1" \
+    | sort \
+    | tail -n1)
+  test $folder_name || return 0
+
+  $GET 2> /dev/null ${MIRROR[$DEFAULT]}/$folder_name/ \
+    | egrep "</a>" \
+    | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' \
+    | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
+    | tail -n1
 }
 
 #


### PR DESCRIPTION
# Pull Request Template:

### Describe what you did

Added support for codenames (currently valid are argon, boron, carbon) for install, bin, and use commands. Added release stream options to README.

### How you did it

Looked up mirror site for latest version in latest-<codename> folder.

### How to verify it doesn't effect the functionality of n

Tested on MacOS.

$ n 8
$ node --version
 v8.11.3
$ n v8.0.0
$ node --version 
v8.0.0
$ n 9.0.0
$ node --version 
v9.0.0
$ n argon
$ node --version 
v4.9.1
$ n boron
$ node --version 
v6.14.3
$ n carbon
$ node --version 
v8.11.3
$ n dubnium
dubnium Error: invalid codename dubnium
$ n latest
$ node --version 
v10.5.0
$ n lts
$ node --version
 v8.11.3

$ n bin v8.0.0
 /usr/local/n/versions/node/8.0.0/bin/node
$ n bin 9.0.0
 /usr/local/n/versions/node/9.0.0/bin/node
$ n bin argon
 /usr/local/n/versions/node/4.9.1/bin/node
$ n bin boron
 /usr/local/n/versions/node/6.14.3/bin/node
$ n bin carbon
 /usr/local/n/versions/node/8.11.3/bin/node
$ n bin latest
 /usr/local/n/versions/node/10.5.0/bin/node
$ n bin lts
 /usr/local/n/versions/node/8.11.3/bin/node

$ n use v8.0.0 --version 
v8.0.0
$ n use 9.0.0 --version 
v9.0.0
$ n use argon --version
 v4.9.1
$ n use boron --version
 v6.14.3
$ n use carbon --version
 v8.11.3
$ n use latest --version
 v10.5.0
$ n use lts --version
 v8.11.3

### If this solves an issue, please put issue in PR notes.

Solves issue #423
Also, remove buggy stripping of leading v from codenames.
Also, made error message for bin and use consistent with looking up version from codename.

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.

Before
$ n boron
Error: invalid version boron
$ n vboron
Error: invalid version boron
$ n bin lts
Error: lts is not installed

After
$ n boron
$ n vboron
Error: invalid codename vboron
$ n bin lts
Error: 8.11.3 is not installed

### Squash any unnecessary commits to keep history clean as possible

###  Place description for the changelog in PR so we can tally all changes for any future release

Added support for codenames (currently valid are argon, boron, carbon) to install, bin, and use commands.