### PR TITLE
Add --insecure (and proxy docs)

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -190,6 +190,7 @@ display_help() {
     -q, --quiet     Disable curl output (if available)
     -d, --download  Download only
     -a, --arch      Override system architecture
+    --insecure      Turn off certificate checking for https requests (may be needed from behind a proxy server)
 
   Aliases:
 
@@ -601,6 +602,18 @@ set_quiet() {
 }
 
 #
+# Set curl/wget to insecure mode
+#
+
+set_insecure() {
+  if command -v curl > /dev/null; then
+    GET="$GET -k"
+  else
+    GET="$GET --no-check-certificate"
+  fi
+}
+
+#
 # Remove <version ...>
 #
 
@@ -778,6 +791,7 @@ else
       -h|--help|help) display_help; exit ;;
       -q|--quiet) set_quiet ;;
       -d|--download) ACTIVATE=false ;;
+      --insecure) set_insecure ;;
       --latest) display_latest_version; exit ;;
       --stable) display_latest_stable_version; exit ;;
       --lts) display_latest_lts_version; exit ;;

--- a/docs/proxy-server.md
+++ b/docs/proxy-server.md
@@ -1,0 +1,96 @@
+# Proxy Server
+
+Under the hood, `n` uses `curl` or `wget` for the downloads. `curl` is used if available, and `wget` otherwise. Both `curl` and `wget` support using environment variables or startup files to set up the proxy.
+
+## Using Environment Variable
+
+You can define the proxy server using an environment variable, which is read by multiple commands including `curl` and `wget`:
+
+    export https_proxy='http://host:port/path'
+
+If your proxy requires authentication you can [url-encode](https://urlencode.org) the username and password in the URL. e.g.
+
+    export https_proxy='http://user:password@host:port/path'
+
+If you have defined a custom node mirror which uses http, then you would define `http_proxy` rather than `https_proxy`.
+
+## Certificate Checks
+
+Your proxy server may supply its own ssl certificates for remote sites (as a man-in-the-middle). If you can not arrange to trust the proxy in this role, you can turn off (all) certificate checking with `--insecure`. e.g.
+
+    n --insecure --lts
+
+Another possible work-around for certificate problems is to use plain http by specifying a custom node mirror:
+
+    export NODE_MIRROR='http://nodejs.org/dist'
+    export http_proxy='http://host:port/path'
+    n --lts
+
+## Startup Files
+
+An alternative to using an environment variable for the proxy settings is to configure a startup file for the command.
+
+Example `~/.curlrc` ([documentation](https://ec.haxx.se/cmdline-configfile.html))
+
+    proxy = http://host:port/path
+    proxy-user = user:password
+    # If need to disable certificate checks
+    --insecure
+
+Example `~/.wgetrc` ([documentation](https://www.gnu.org/software/wget/manual/html_node/Wgetrc-Commands.html#Wgetrc-Commands))
+
+    https_proxy = http://host:port/path
+    proxy_user = user
+    proxy_password = password
+    # If need to disable certificate checks
+    check_certificate = off
+
+## Troubleshooting
+
+To experiment and find what settings you need, use `curl` (or `wget`) directly with the node mirror and check the error messages.
+
+For these examples there is a proxy running on localhost:8080 which does not require authentication, but the certificates it offers
+are not trusted.
+
+First try fails because of the certificates and `curl` helpfully explains:
+
+    $ curl --proxy localhost:8080 https://nodejs.org/dist/
+    curl: (60) SSL certificate problem: self signed certificate in certificate chain
+    ...
+    If you'd like to turn off curl's verification of the certificate, use
+     the -k (or --insecure) option.
+    HTTPS-proxy has similar options --proxy-cacert and --proxy-insecure.
+
+Once you get the command to work with settings appropriate for your setup, like:
+
+    $ curl --insecure --proxy localhost:8080 https://nodejs.org/dist/
+    <html>
+    <head><title>Index of /dist/</title></head>
+    ...
+
+then you can try moving the proxy out of the command:
+
+    $ https_proxy=localhost:8080 curl --insecure https://nodejs.org/dist/
+    <html>
+    <head><title>Index of /dist/</title></head>
+    ...
+
+and then `n` should work the same way:
+
+    $ https_proxy=localhost:8080 n --insecure --lts
+    8.11.3
+
+To make it permanent either add settings to the `curl` (or `wget`) startup file, or add the
+environment variable to your shell initialization file . e.g.
+
+    export https_proxy=localhost:8080
+
+For curl, two options of note for debugging are:
+
+    -v, --verbose
+    Makes curl verbose during the operation. Useful for debugging
+    and seeing what's going on "under the hood". ...
+
+    -q, --disable
+    If used as the first parameter on the command line,
+    the curlrc config file will not be read and used. ...


### PR DESCRIPTION
# Pull Request Template:

### Describe what you did

Added option for `--insecure` for working from behind a proxy which uses untrusted certificates. 

### How you did it

Separate commits so can cherrypick if desired:
1) Added `--insecure` option to n, and use it to disable certificate checks for curl/wget.
2) Added separate documentation on setting up proxy.

NB: wget options are still insecure by default. However, this change hopefully removes an obstacle to changing the wget default options in the future.

### How to verify it doesn't effect the functionality of n

Code inspection that this is a new code path and will not affect previous use cases.

### If this solves an issue, please put issue in PR notes.

This option is partly to make it possible to use curl now when insecure is needed, and partly to allow making wget secure by default in future and bring it into line with curl.

Makes curl insecure opt-in, and not by default as suggested here: #323 #324 #426 

Make wget secure by default in future: #475 #509 

Other proxy related issues where `--insecure` could help: #284 #430 #503 #517

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.

Running a local proxy with MITM certificates to demonstrate:

    $ export https_proxy=localhost:8080 
    $ n --lts
    $ n lts
    
    Error: invalid version 
    
    $ n --insecure --lts
    8.11.3
    $ n --insecure lts
    
         install : node-v8.11.3
           mkdir : /usr/local/n/versions/node/8.11.3
           fetch : https://nodejs.org/dist/v8.11.3/node-v8.11.3-darwin-x64.tar.gz
       installed : v8.11.3

### Squash any unnecessary commits to keep history clean as possible

###  Place description for the changelog in PR so we can tally all changes for any future release

Added: --insecure option to disable certificate checks

[Suggested addition]
Note: if curl is not present and `n` is using wget, the certificate check has historically been disabled and that behaviour has not changed yet. In the future this may change (and you can add the` --insecure` option now so will not be affected when it does change).