### PR TITLE
Hide cursor while selecting version from menu

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -121,12 +121,18 @@ set_arch() {
 #
 
 enter_fullscreen() {
-  tput smcup
+  # Set cursor to be invisible
+  tput civis 2> /dev/null
+  # Save screen contents
+  tput smcup 2> /dev/null
   stty -echo
 }
 
 leave_fullscreen() {
-  tput rmcup
+  # Set cursor to normal
+  tput cnorm 2> /dev/null
+  # Restore screen contentsq
+  tput rmcup 2> /dev/null
   stty echo
 }
 
@@ -205,22 +211,6 @@ err_no_installed_print_help() {
   printf "\n  \033[31mError: no installed version\033[0m\n"
   display_help
   exit 1
-}
-
-#
-# Hide cursor.
-#
-
-hide_cursor() {
-  printf "\e[?25l"
-}
-
-#
-# Show cursor.
-#
-
-show_cursor() {
-  printf "\e[?25h"
 }
 
 #


### PR DESCRIPTION
# Pull Request Template:

### Describe what you did

Hide cursor while selecting node version from menu (i.e. `nvh` with no parameters).

### How you did it

Added calls to `tput` to hide and show cursor in `enter_fullscreen` and `leave_fullscreen`. These two routines already use `tput` to save and restore the screen contents.

Added redirection to suppress stderr just in case tput calls not supported by termcap. 

Deleted unused code to hide and show cursor using direct escape sequences.

### How to verify it doesn't effect the functionality of n

Cosmetic only, not functional.
Tried the termcap calls on Mac High Sierra, Mac Mojave, Ubuntu, Centos, and archlinux.

### If this solves an issue, please put issue in PR notes.

On macOS there was a cursor left on screen below version list during version selection from menu, and sometimes a padlock would appear while moving selected version using arrow keys.

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.

(graphic difference)

### Squash any unnecessary commits to keep history clean as possible

###  Place description for the changelog in PR so we can tally all changes for any future release

Hide cursor while selecting node version from currently installed versions using menu.