### PR TITLE
Remove bogus shift from prune function (issue #529)

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -626,7 +626,6 @@ prune_versions() {
     then
       echo $version
       rm -rf ${BASE_VERSIONS_DIR[$DEFAULT]}/$version
-      shift
     fi
   done
 }


### PR DESCRIPTION
# Pull Request Template:

### Describe what you did

Fix return status of `n prune` when some versions deleted.

### How you did it

Removed bogus `shift`

### How to verify it doesn't effect the functionality of n

Code inspection as only one word change. Removed a call to `shift` in a routine which takes no parameters. Tested on macOS and Centos.

### If this solves an issue, please put issue in PR notes.

Solves issue #529

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.

```bash
 $ n latest
     install : node-v10.12.0
       mkdir : /usr/local/n/versions/node/10.12.0
       fetch : https://nodejs.org/dist/v10.12.0/node-v10.12.0-darwin-x64.tar.gz
   installed : v10.12.0
$ n prune
node/8.12.0
$ n lts
     install : node-v8.12.0
       mkdir : /usr/local/n/versions/node/8.12.0
       fetch : https://nodejs.org/dist/v8.12.0/node-v8.12.0-darwin-x64.tar.gz
   installed : v8.12.0
$ n prune
node/10.12.0
```

Before:
```bash
$ echo $?
1
```

After:
```bash
$ echo $?
0
```
### Squash any unnecessary commits to keep history clean as possible

###  Place description for the changelog in PR so we can tally all changes for any future release

Fix shell return status from `n prune`.