### PR TITLE
Change which to command -v

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -262,7 +262,7 @@ check_current_version() {
     for bin in ${BINS[@]}; do
       if diff &> /dev/null \
         $BASE_VERSIONS_DIR/$bin/$current/bin/node \
-        $(which node) ; then
+        $(command -v node) ; then
         active=$bin/$current
       fi
     done
@@ -622,7 +622,7 @@ remove_versions() {
 prune_versions() {
   check_current_version
   for version in $(versions_paths); do
-    if [ $version != $active ]
+    if [ "$version" != "$active" ]
     then
       echo $version
       rm -rf ${BASE_VERSIONS_DIR[$DEFAULT]}/$version


### PR DESCRIPTION
# Pull Request Template:

### Describe what you did

Fix some issues on an OS without `which`, such as Centos docker image.

### How you did it

Changed `which` to `command -v` in the `check_current_version` routine.

Also added speech marks around variable dereference to fix error message that occurred before fixing above.

### How to verify it doesn't effect the functionality of n

Checked `n` and `n prune` on MacOS and Centos.

### If this solves an issue, please put issue in PR notes.

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.

Before (with no `which` command):
```bash
# n prune
/usr/local/bin/n: line 263: which: command not found
/usr/local/bin/n: line 263: which: command not found
/usr/local/bin/n: line 625: [: node/10.12.0: unary operator expected
```

After:
```bash
# n prune
```

### Squash any unnecessary commits to keep history clean as possible

###  Place description for the changelog in PR so we can tally all changes for any future release

Remove use of `which` and use generally available `command -v`.