### PR TITLE
Mention brew install n

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ to install `n` to `bin/n` of the directory specified in the environment variable
 Once installed, `n` installs `node` versions to subdirectory `n/versions` of the directory specified in environment variable `N_PREFIX`, which defaults to `/usr/local`; the _active_ `node`/`iojs` version is installed directly in `N_PREFIX`.
 To change the default to, say, `$HOME`, prefix later calls to `n` with `N_PREFIX=$HOME ` or add `export N_PREFIX=$HOME` to your shell initialization file.
 
+On macOS with [Homebrew](https://brew.sh/) you can install the [`n` formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/n.rb). Does not require installing `node` first.
+
+    brew install n
+
 Additionally, consider third-party installer [n-install](https://github.com/mklement0/n-install), which allows installation directly from GitHub; for instance,
 
     curl -L https://git.io/n-install | bash


### PR DESCRIPTION
- The popular macOS package manager `brew` has a formula for `n`, maintained by the Homebrew community.
- Does not require installing `node`/`npm` first.
- The `n` formula was installed 1401 times in the past 30 days (as of 2018-10-28T09:01:04Z).
- This commit adds the installation method below the `npm` and `make` methods, but above `n-install`, in `README.md`.

```shell
brew install n
```

See

- https://brew.sh/
- https://github.com/Homebrew/homebrew-core/blob/master/Formula/n.rb
- https://formulae.brew.sh/analytics/install/30d/
- https://formulae.brew.sh/api/analytics/install/homebrew-core/30d.json
