### PR TITLE
Improved timeliness of LTS changes across major versions

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -723,16 +723,12 @@ display_latest_stable_version() {
 
 display_latest_lts_version() {
   check_io_supported "--lts"
-  local folder_name=$($GET 2> /dev/null ${MIRROR[$DEFAULT]} \
-    | egrep "</a>" \
-    | egrep -o 'latest-[a-z]{2,}' \
-    | sort \
-    | tail -n1)
-
-  $GET 2> /dev/null ${MIRROR[$DEFAULT]}/$folder_name/ \
-    | egrep "</a>" \
-    | egrep -o '[0-9]+\.[0-9]+\.[0-9]+' \
-    | head -n1
+  local version=$($GET 2> /dev/null ${MIRROR[$DEFAULT]}/index.tab \
+    | egrep -v "\-$" \
+    | head -n 2 \
+    | tail -n 1 \
+    | cut -f1)
+  echo ${version#v}
 }
 
 #


### PR DESCRIPTION
### Describe what you did
Changed display_latest_lts_version to use index.tab file for retrieving the lts version

### How you did it
Added /index.tab to path for GET request to mirror, piped output to locate only "lts" rows, took only the first one, discarding header row.

### How to verify it doesn't effect the functionality of n
Modified output to conform with previous style (specifically, removing the "v" prefix from version number, output matches existing functionality so should not break existing dependents).

### If this solves an issue, please put issue in PR notes.
N/A

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.
N/A

### Squash any unnecessary commits to keep history clean as possible
Completed prior to opening PR

###  Place description for the changelog in PR so we can tally all changes for any future release
Changed display_latest_lts_version to use index.tab file for retrieving the lts version