### PR TITLE
Fix menu selection when installed version not present

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -227,7 +227,7 @@ show_cursor() {
 #
 
 next_version_installed() {
-  list_versions_installed | grep $selected -A 1 | tail -n 1
+  list_versions_installed | grep "$selected" -A 1 | tail -n 1
 }
 
 #
@@ -235,7 +235,7 @@ next_version_installed() {
 #
 
 prev_version_installed() {
-  list_versions_installed | grep $selected -B 1 | head -n 1
+  list_versions_installed | grep "$selected" -B 1 | head -n 1
 }
 
 #
@@ -606,10 +606,8 @@ set_quiet() {
 
 remove_versions() {
   test -z $1 && abort "version(s) required"
-  check_current_version
   while test $# -ne 0; do
     local version=${1#v}
-    [ "${BINS[$DEFAULT]}/$version" == "$active" ] && abort "cannot remove currently active version ($active)"
     rm -rf ${VERSIONS_DIR[$DEFAULT]}/$version
     shift
   done


### PR DESCRIPTION
# Pull Request Template:

### Describe what you did

Fixed menu selection when active node version is not present in list. (#292 #367 #400)

Removing prior work-around in PR #296 which blocked calling `n rm` on the active version, but that causes some confusion when people trying to uninstall. (#169 #327 #441) 

### How you did it

Added speech marks around variable dereference in prev/next called when moving menu selection up or down.

Deleted now unnecessary lines of code blocking removal of current version.

### How to verify it doesn't effect the functionality of n

Code inspection (simple changes). 
Verify menu selection still works using `n`.
Remove a cached version using `n rm <version>`.

### If this solves an issue, please put issue in PR notes.

Solves #292 #367 #391 #400

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.

```bash
$ n 4.9.1
$ n 8.14.0
$ rm -rf /usr/local/n/versions/node/8.14.0
$ n 
(hit up or down arrow)

usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
	[-e pattern] [-f file] [--binary-files=value] [--color=when]
	[--context[=num]] [--directories=action] [--label] [--line-buffered]
	[--null] [pattern] [file ...]

    node/4.9.1
```

Menu selection works in this situation after fix. Hitting the up/down arrow from first display moves selected item to top/bottom version, with no error message displayed.

### Squash any unnecessary commits to keep history clean as possible

###  Place description for the changelog in PR so we can tally all changes for any future release

Fix menu selection of cached node versions when active node version is not present in cache. Allow removal of active node version from cache.