### PR TITLE
Add partial version number to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,20 @@ As a result, both `n` itself and all `node` versions it manages are hosted insid
 ### Installing/Activating Versions
 
 Simply execute `n <version>` to install a version of `node`. If `<version>` has already been installed (via `n`), `n` will activate that version.
+A leading v is optional, and a partial version number installs the newest matching version.
 
-    $ n 0.8.14
-    $ n 0.8.17
-    $ n 0.9.6
+    $ n 4.9.1
+    $ n 10
+    $ n v8.11.3
 
 Execute `n` on its own to view your currently installed versions. Use the up and down arrow keys to navigate and press enter to select. Use `q` or ^C (control + C) to exit the selection screen.
 If you like vim key bindings during the selection of node versions, you can use `j` and `k` to navigate up or down without using arrows.
 
     $ n
 
-      0.8.14
-    ο 0.8.17
-      0.9.6
+      node/4.9.1
+    ο node/8.11.3
+      node/10.15.0
 
 Use or install the latest official release:
 


### PR DESCRIPTION
# Pull Request Template:

Being able to specify partial version number like `n 8` is a handy shortcut that has been implemented but is not documented.

### Describe what you did

- add text and example for optional leading v
- add text and example for partial number
- (use more recent version numbers!)
- update menu example to match
- update menu example to have `node/` to match actual behaviour

### How you did it

Edit README.

### How to verify it doesn't effect the functionality of n

No code changes.

### If this solves an issue, please put issue in PR notes.



### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.



### Squash any unnecessary commits to keep history clean as possible

###  Place description for the changelog in PR so we can tally all changes for any future release

Add example of installing with partial version number, and optional leading v.