### PR TITLE
Add NODE_MIRROR to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,13 @@ Output can also be obtained from `n --help`.
       -       rm
       stable  lts
 
-## Custom source
+## Custom Mirror
+
+If you would like to use a mirror site instead of the official Node.js downloads at `https://nodejs.org/dist/`, you can define `NODE_MIRROR`. For example:
+
+    NODE_MIRROR="https://npm.taobao.org/mirrors/node/"
+
+## Custom Project
 
 If you would like to use a project other than the official Node.js project, you can use the special `n project [command]` which allows you to control the behavior of `n` using environment variables.
 


### PR DESCRIPTION
# Pull Request Template:

Document the NODE_MIRROR environment variable available for specifying mirror site, dating back to this commit:
<https://github.com/tj/n/commit/42df056cdf1e8876b26d978875d297dc48ebaada>

### Describe what you did

Documented NODE_MIRROR usage.

### How you did it

Added a README section covering use of NODE_MIRROR to specify node mirror site.

### How to verify it doesn't effect the functionality of n

No code changes.

### If this solves an issue, please put issue in PR notes.

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.

### Squash any unnecessary commits to keep history clean as possible

###  Place description for the changelog in PR so we can tally all changes for any future release

Added documentation for setting NODE_MIRROR to specify a node mirror to use for downloads.