### PR TITLE
installation folder became dynamic

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -5,7 +5,7 @@
 #
 
 VERSION="2.1.12"
-N_PREFIX=${N_PREFIX-/usr/local}
+N_PREFIX=`which npm  | rev | cut -c9- | rev`
 BASE_VERSIONS_DIR=$N_PREFIX/n/versions
 
 #


### PR DESCRIPTION
# Pull Request Template:

### Describe what you did
 make installation directory auto detected.

### How you did it

grep current **npm**  directory  using `which npm`

### How to verify it doesn't effect the functionality of n
firstly I manually installed node.js in this directory `/home/myUserName/.local` because I don't want run **sudo** every time when I need to install a global package so [n](https://github.com/tj/n) didn't work with me. by review the code I found the installation directory assigned statically to "N_PREFIX" variable, so I assigned this command result to it and _voila_  finally worked.
