### PR TITLE
Feature: xz compression option

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -406,6 +406,7 @@ tarball_url() {
   local uname="$(uname -a)"
   local arch=x86
   local os=
+  local ext=gz
 
   # from nave(1)
   case "$uname" in
@@ -431,7 +432,9 @@ tarball_url() {
 
   [ -n "$ARCH" ] && arch="$ARCH"
 
-  echo "${MIRROR[$DEFAULT]}v${version}/${BIN_NAME[$DEFAULT]}-v${version}-${os}-${arch}.tar.gz"
+  [ -n "$N_USE_XZ" ] && ext="xz"
+
+  echo "${MIRROR[$DEFAULT]}v${version}/${BIN_NAME[$DEFAULT]}-v${version}-${os}-${arch}.tar.${ext}"
 
 }
 
@@ -541,6 +544,12 @@ install() {
 
   local dir="${VERSIONS_DIR[$DEFAULT]}/$version"
 
+  if test -n "$N_USE_XZ"; then
+    local tarflag="-Jx"
+  else
+    local tarflag="-zx"
+  fi
+
   if test -d "$dir"; then
     if [[ ! -e "$dir/n.lock" ]] ; then
       if "$ACTIVATE" ; then
@@ -566,7 +575,7 @@ install() {
   cd "$dir"
 
   log fetch "$url"
-  $GET "$url" | tar -zx --strip-components=1
+  $GET "$url" | tar "$tarflag" --strip-components=1
   [ "$QUIET" == false ] && erase_line
   rm -f "$dir/n.lock"
 


### PR DESCRIPTION
# Pull Request Template:

### Describe what you did

Add the option to download a `.tar.xz` tarball instead of a `.tar.gz` tarball

### How you did it

- in bin/n, check for an environment variable `EXTENSION`.

- If `EXTENSION` is set, use this in `tarball_url()` to set the URL to end in (effectively) `.tar."$EXTENSION"` rather than `.tar.gz`... 
- AND also use this in `install()` to set the tar extraction flags to `-Jx` (for extracting an xz-compressed archive) if `$EXTENSION` evaluates to `xz`

Also changed an error message to now alert the user if they have given an invalid extension.

By default, if the environment variable `EXTENSION` is unset, the script will set it to "gz" to use gzip compression.

### How to verify it doesn't effect the functionality of n

n 10 (or similar)...

(with and without `EXTENSION` environment variable set to `xz`)

### If this solves an issue, please put issue in PR notes.

Nope, I went directly to a PR with this.

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.

N/A

### Squash any unnecessary commits to keep history clean as possible

- [x]

###  Place description for the changelog in PR so we can tally all changes for any future release

- Add option to download .tar.xz instead of .tar.gz, via environment variable "EXTENSION"