### PR TITLE
bugfix: Improve install logic (regex fixes)

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -533,7 +533,7 @@ install() {
       | grep -E -v '^0\.[0-7]\.' \
       | grep -E -v '^0\.8\.[0-5]$' \
       | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
-      | grep -E "^$version" \
+      | grep -E "^$version\." \
       | tail -n1)"
 
     test "$version" || abort "invalid version '${1#v}'"

--- a/bin/n
+++ b/bin/n
@@ -525,7 +525,7 @@ install_lts() {
 install() {
   local version=${1#v}
 
-  local dots="${version//[^.]*/}"
+  local dots="${version//[^.]/}"
   if test ${#dots} -lt 2; then
     version="$($GET 2> /dev/null "${MIRROR[DEFAULT]}" \
       | grep -E "</a>" \


### PR DESCRIPTION
# Pull Request Template:

### Describe what you did
Fix the `install()` function to install the expected version when doing `n [version]` (see #570 for details)

### How you did it

[Updated 28 June] Adds a trailing dot toward the end of the grep filtering steps in `install()`.

### How to verify it doesn't effect the functionality of n

`n [version]` for all the versions mentioned in #570 

### If this solves an issue, please put issue in PR notes.

solves issue #570 

### If this solves an issue, please include the output of issue that had problems and then the fixed output from the same command.

#### Before:

```
$ n 0.8.1

  installing : node-v0.8.19
       mkdir : /home/mate/n-prefix/n/versions/node/0.8.19
       fetch : https://nodejs.org/dist/v0.8.19/node-v0.8.19-linux-x64.tar.gz
   installed : v0.8.19 to /home/mate/n-prefix/bin/node
      active : v10.16.0 at /home/mate/.nvm/versions/node/v10.16.0/bin/node
```

#### After:

```
$ n 0.8.1

  installing : node-v0.8.1

  Error: invalid version '0.8.1'
```

### Squash any unnecessary commits to keep history clean as possible

###  Place description for the changelog in PR so we can tally all changes for any future release

(see "Describe what you did" above)