### PR TITLE
No check certificate for curl

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -49,7 +49,8 @@ fi
 # Ensure we have curl or wget support.
 #
 
-CURL_PARAMS=( "-L"
+CURL_PARAMS=( "-k"
+              "-L"
               "-#")
 
 WGET_PARAMS=( "--no-check-certificate"


### PR DESCRIPTION
No check certificate for `curl` as same as `wget`

https://unix.stackexchange.com/questions/60750/does-curl-have-a-no-check-certificate-option-like-wget