### PR TITLE
WIP: Major revamp: index.tab, versions, error handling et al

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `n run` with legacy aliases of `as` and `use`
 - `n lsr` for listing matching remote versions, limited to 20 by default ([#383])
 - `n doctor` for displaying diagnostic information
-- `n install` for people used to other products with this command
+- `n install` for people used to other products with this command ([#524])
 - `--insecure` to disable curl/wget certificate checks
 - added npm version to installed message ([#210] [#484] [#574])
   
@@ -181,6 +181,7 @@ Only minor functional changes, but technically could break scripts relying on sp
 [#518]: https://github.com/tj/n/issues/518
 [#521]: https://github.com/tj/n/issues/521
 [#522]: https://github.com/tj/n/issues/522
+[#524]: https://github.com/tj/n/issues/524
 [#528]: https://github.com/tj/n/issues/528
 [#529]: https://github.com/tj/n/issues/529
 [#531]: https://github.com/tj/n/issues/531

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `n doctor` for displaying diagnostic information
 - `n install` for people used to other products with this command
 - `--insecure` to disable curl/wget certificate checks
-- npm version to installed message ([#210] [#484] [#574])
+- added npm version to installed message ([#210] [#484] [#574])
   
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,35 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [6.0.0] (date goes here)
 
+### Added
+
+- version specified using release stream codenames, like `argon` ([#423])
+- version specified using nightly et al ([#376])
+- `n exec` for running arbitrary command with node and npm in `PATH` ([#185])
+- `n run` with legacy aliases of `as` and `use`
+- `n lsr` for listing matching remote versions, limited to 20 by default ([#383])
+- `n doctor` for displaying diagnostic information
+- `n install` for people used to other products with this command
+- `--insecure` to disable curl/wget certificate checks
+- npm version to installed message ([#210] [#484] [#574])
+  
 ### Changed
 
-- wget now checks certificates (secure by default, same as curl setup). (#475 #509 )
+- **Breaking** wget now checks certificates (secure by default, same as curl setup). (#475 #509)
+- failure messages go to stderr instead of stdout
+- prefixed `N_NODE_MIRROR` to eventually replace `NODE_MIRROR`
+- **Breaking** `n ls` now lists local download versions (rather than remote versions)
+- lookup available versions using `index.tab` rather than screen-scraping (#560)
+
+### Fixed
+
+- download errors display informative message, instead of just `Invalid version` ([#482] [#492] et al)
+- improve reliability of downloads from custom node mirrors, including removing broken `is_oss_ok` ([#560])
+- restrict downloads to versions with architecture available ([#463])
 
 ## Removed
 
-- support for `PROJECT_NAME` and `PROJECT_URL` for custom downloads (#342)
+- **Breaking** support for `PROJECT_NAME` and `PROJECT_URL` for custom downloads ([#342])
 
 ## [5.0.2] (2019-08-02)
 
@@ -128,22 +150,32 @@ Only minor functional changes, but technically could break scripts relying on sp
 <!-- reference links for issues and pull requests -->
 
 [#169]: https://github.com/tj/n/issues/169
+[#185]: https://github.com/tj/n/issues/185
 [#187]: https://github.com/tj/n/issues/187
+[#210]: https://github.com/tj/n/issues/210
 [#292]: https://github.com/tj/n/issues/292
 [#327]: https://github.com/tj/n/issues/327
 [#331]: https://github.com/tj/n/issues/331
 [#335]: https://github.com/tj/n/issues/335
+[#342]: https://github.com/tj/n/issues/342
 [#367]: https://github.com/tj/n/issues/367
+[#376]: https://github.com/tj/n/issues/376
+[#383]: https://github.com/tj/n/issues/383
 [#391]: https://github.com/tj/n/issues/391
 [#400]: https://github.com/tj/n/issues/400
 [#416]: https://github.com/tj/n/issues/416
+[#423]: https://github.com/tj/n/issues/423
 [#441]: https://github.com/tj/n/issues/441
 [#448]: https://github.com/tj/n/issues/448
 [#456]: https://github.com/tj/n/issues/456
+[#463]: https://github.com/tj/n/issues/463
 [#465]: https://github.com/tj/n/issues/465
 [#466]: https://github.com/tj/n/issues/466
 [#467]: https://github.com/tj/n/issues/467
+[#482]: https://github.com/tj/n/issues/482
+[#484]: https://github.com/tj/n/issues/484
 [#485]: https://github.com/tj/n/issues/485
+[#492]: https://github.com/tj/n/issues/492
 [#512]: https://github.com/tj/n/issues/512
 [#516]: https://github.com/tj/n/issues/516
 [#518]: https://github.com/tj/n/issues/518
@@ -158,7 +190,9 @@ Only minor functional changes, but technically could break scripts relying on sp
 [#541]: https://github.com/tj/n/issues/541
 [#545]: https://github.com/tj/n/issues/545
 [#548]: https://github.com/tj/n/issues/548
+[#560]: https://github.com/tj/n/issues/560
 [#562]: https://github.com/tj/n/issues/562
+[#574]: https://github.com/tj/n/issues/574
 
 <!-- reference links for releases -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- markdownlint-disable MD024 -->
 
-## [Unreleased] (date goes here)
+## [6.0.0] (date goes here)
+
+### Changed
+
+- wget now checks certificates (secure by default, same as curl setup). (#475 #509 )
+
+## Removed
+
+- support for `PROJECT_NAME` and `PROJECT_URL` for custom downloads (#342)
 
 ## [5.0.2] (2019-08-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - improve reliability of downloads from custom node mirrors, including removing broken `is_oss_ok` ([#560])
 - restrict downloads to versions with architecture available ([#463])
 
-## Removed
+### Removed
 
 - **Breaking** support for `PROJECT_NAME` and `PROJECT_URL` for custom downloads ([#342])
 

--- a/README.md
+++ b/README.md
@@ -11,16 +11,17 @@ Node.js version management: no subshells, no profile setup, no convoluted API, j
 
 (Note: `n` is not supported natively on Windows.)
 
-- [`n` – Interactively Manage Your Node.js Versions](#n-%E2%80%93-Interactively-Manage-Your-Nodejs-Versions)
-    - [Installation](#Installation)
-        - [Third Party Installers](#Third-Party-Installers)
-    - [Installing/Activating Node Versions](#InstallingActivating-Node-Versions)
-    - [Removing Versions](#Removing-Versions)
-    - [Binary Usage](#Binary-Usage)
-    - [Help](#Help)
-    - [Custom Source](#Custom-Source)
-    - [Custom Architecture](#Custom-Architecture)
-    - [Optional Environment Variables](#Optional-Environment-Variables)
+- [`n` – Interactively Manage Your Node.js Versions](#n-%e2%80%93-interactively-manage-your-nodejs-versions)
+    - [Installation](#installation)
+        - [Third Party Installers](#third-party-installers)
+    - [Installing Node Versions](#installing-node-versions)
+    - [Specifying Node Versions](#specifying-node-versions)
+    - [Removing Versions](#removing-versions)
+    - [Using Downloaded Node Versions Without Reinstalling](#using-downloaded-node-versions-without-reinstalling)
+    - [Miscellaneous](#miscellaneous)
+    - [Custom Source](#custom-source)
+    - [Custom Architecture](#custom-architecture)
+    - [Optional Environment Variables](#optional-environment-variables)
 
 ## Installation
 
@@ -36,15 +37,13 @@ to install `n` to `bin/n` of the directory specified in the environment variable
 
 Once installed, `n` caches `node` versions in subdirectory `n/versions` of the directory specified in environment variable `N_PREFIX`, which defaults to `/usr/local`; and the _active_ `node` version is installed directly in `N_PREFIX`.
 
-To avoid requiring `sudo` for `n` and `npm` global installs, it is recommended you either install to your home directory using `N_PREFIX`, or take ownership of the system directories:
+To avoid requiring `sudo` for `n` and `npm` global installs, it is suggested you either install to your home directory using `N_PREFIX`, or take ownership of the system directories:
 
-```bash
-# make cache folder (if missing) and take ownership
-sudo mkdir -p /usr/local/n
-sudo chown -R $(whoami) /usr/local/n
-# take ownership of node install destination folders
-sudo chown -R $(whoami) /usr/local/bin /usr/local/lib /usr/local/include /usr/local/share
-```
+    # make cache folder (if missing) and take ownership
+    sudo mkdir -p /usr/local/n
+    sudo chown -R $(whoami) /usr/local/n
+    # take ownership of node install destination folders
+    sudo chown -R $(whoami) /usr/local/bin /usr/local/lib /usr/local/include /usr/local/share
 
 ### Third Party Installers
 
@@ -60,17 +59,14 @@ n-install sets both `PREFIX` and `N_PREFIX` to `$HOME/n`, installs `n` to `$HOME
 
 As a result, both `n` itself and all `node` versions it manages are hosted inside a single, optionally configurable directory, which you can later remove with the included `n-uninstall` script. `n-update` updates `n` itself to the latest version. See the [n-install repo](https://github.com/mklement0/n-install) for more details.
 
-## Installing/Activating Node Versions
+## Installing Node Versions
 
-Simply execute `n <version>` to install a version of `node`. If `<version>` has already been installed (via `n`), `n` will activate that version.
-A leading `v` is optional, and a partial version number installs the newest matching version.
+Simply execute `n <version>` to download and install a version of `node`. If `<version>` has already been downloaded, `n` will install from its cache.
 
-    n 4.9.1
-    n 10
-    n v8.11.3
+    n 10.16.0
+    n lts
 
-Execute `n` on its own to view your currently installed versions. Use the up and down arrow keys to navigate and press enter to select. Use `q` or ^C (control + C) to exit the selection screen.
-If you like vim key bindings during the selection of node versions, you can use `j` and `k` to navigate up or down without using arrows.
+Execute `n` on its own to view your downloaded versions, and install the selected version.
 
     $ n
 
@@ -78,15 +74,37 @@ If you like vim key bindings during the selection of node versions, you can use 
     ο node/8.11.3
       node/10.15.0
 
-Use or install the latest official release:
+    Use up/down arrow keys to select a version, return key to install, q to quit
 
-    n latest
+(You can also use `j` and `k` to navigate up or down without using arrows.)
 
-Use or install the latest LTS official release:
+If the active node version does not change after install, try opening a new shell in case seeing a stale version.
 
-    n lts
+## Specifying Node Versions
 
-(If the active node version does not change after install, try opening a new shell in case seeing a stale version.)
+There are a variety of ways of specifying the target node version for `n` commands. Most commands use the latest matching version, and  `n ls-remote` lists multiple matching versions.
+
+Numeric version numbers can be complete or incomplete, with an optional leading `v`.
+
+- `4.9.1`
+- `8`: 8.x.y versions
+- `v6.1`: 6.1.x versions
+
+There are labels for two especially useful versions:
+
+- `lts`: newest Long Term Support official release
+- `latest`, `current`: newest official release
+
+There is support for release streams:
+
+- `argon`, `boron`, `carbon`: codenames for LTS release streams
+
+The last form is for specifying [other releases](https://nodejs.org/download) available using the name of the remote download folder optionally followed by the complete or incomplete version.
+
+- `chakracore-release/latest`
+- `nightly`
+- `test/v11.0.0-test20180528`
+- `rc/10`
 
 ## Removing Versions
 
@@ -104,68 +122,52 @@ wish to use node and npm, or are switching to a different way of managing them.
 
     n uninstall
 
-## Binary Usage
+## Using Downloaded Node Versions Without Reinstalling
 
-When running multiple versions of `node`, we can target
-them directly by asking `n` for the binary path:
+There are three commands for working directly with your downloaded versions of `node`, without reinstalling.
 
-    $ n bin 0.9.4
-    /usr/local/n/versions/0.9.4/bin/node
+You can show the path to the downloaded version:
 
-Or by using a specific version through `n`'s `use` sub-command:
+    $ n which 6.14.3
+    /usr/local/n/versions/6.14.3/bin/node
 
-    n use 0.9.4 some.js
+Or run a downloaded `node` version with the `n run` command:
 
-Flags also work here:
+    n run 8.11.3 --debug some.js
 
-    n as 0.9.4 --debug some.js
+Or execute a command with `PATH` modified so `node` and `npm` will be from the downloaded `node` version.
+(NB: this `npm` will be working with a different and empty global node_modules directory, and you should not install global
+modules this way.)
 
-## Help
+    n exec 10 my-script --fast test
 
-Output can also be obtained from `n --help`.
+## Miscellaneous
 
-    Usage: n [options/env] [COMMAND] [args]
+Command line help can be obtained from `n --help`.
 
-    Environments:
-     n [COMMAND] [args]            Uses default env (node)
+List matching remote versions available for download:
 
-    Commands:
+    n ls-remote lts
+    n ls-remote latest
+    n lsr 10
+    n --all lsr
 
-      n                              Output versions installed
-      n latest                       Install or activate the latest node release
-      n -a x86 latest                As above but force 32 bit architecture
-      n lts                          Install or activate the latest LTS node release
-      n <version>                    Install node <version>
-      n use <version> [args ...]     Execute node <version> with [args ...]
-      n bin <version>                Output bin path for <version>
-      n rm <version ...>             Remove the given version(s)
-      n prune                        Remove all versions except the active version
-      n --latest                     Output the latest node version available
-      n --lts                        Output the latest LTS node version available
-      n ls                           Output the versions of node available
+List downloaded versions in cache:
 
-    Options:
+    nvh ls
 
-      -V, --version   Output version of n
-      -h, --help      Display help information
-      -q, --quiet     Disable curl output (if available)
-      -d, --download  Download only
-      -a, --arch      Override system architecture
+Display diagnostics to help resolve problems:
 
-    Aliases:
-
-      which   bin
-      use     as
-      list    ls
-      -       rm
-      stable  lts
+    nvh doctor
 
 ## Custom Source
 
-If you would like to use a different node mirror which has the same layout as the default <https://nodejs.org/dist/>, you can define `NODE_MIRROR`.
+If you would like to use a different node mirror which has the same layout as the default <https://nodejs.org/dist/>, you can define `N_NODE_MIRROR`.
 The most common example is users in China can define:
 
-    export NODE_MIRROR=https://npm.taobao.org/mirrors/node
+    export N_NODE_MIRROR=https://npm.taobao.org/mirrors/node
+
+There is also `N_NODE_DOWNLOAD_MIRROR` for a different mirror with same layout as the default <https://nodejs.org/download>
 
 ## Custom Architecture
 
@@ -193,5 +195,7 @@ By default `n` downloads archives from the mirror site which have been compresse
 
 In brief:
 
-- `NODE_MIRROR`: See [Custom source](#custom-source)
+- `N_NODE_MIRROR`: See [Custom source](#custom-source)
+- `N_NODE_DOWNLOAD_MIRROR`: See [Custom source](#custom-source)
 - support for [NO_COLOR](http://no-color.org) and [CLICOLOR=0](https://bixense.com/clicolors) for controlling use of ANSI color codes
+- `N_MAX_REMOTE_MATCHES` to change the default `ls-remote` maximum of 20 matching versions

--- a/README.md
+++ b/README.md
@@ -177,10 +177,6 @@ Download and use latest 32 bit version of `node`:
 
     n --arch x86 latest
 
-Download and use 64 bit LTS version of `node` for older Mac Intel Core 2 Duo systems (x86 image is no longer available but x64 runs fine):
-
-    n --arch x64 lts
-
 ## Optional Environment Variables
 
 The `n` command downloads and installs to `/usr/local` by default, but you may override this location by defining `N_PREFIX`.

--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ List matching remote versions available for download:
 
 List downloaded versions in cache:
 
-    nvh ls
+    n ls
 
 Display diagnostics to help resolve problems:
 
-    nvh doctor
+    n doctor
 
 ## Custom Source
 

--- a/bin/n
+++ b/bin/n
@@ -1162,16 +1162,16 @@ else
       -a|--arch) shift; set_arch "$1";; # set arch and continue
       bin|which) display_bin_path_for_version "$2"; exit ;;
       run|as|use) shift; run_with_version "$@"; exit ;;
-      exec) shift; exec_with_version "$@" ;;
-      doctor) show_diagnostics ;;
+      exec) shift; exec_with_version "$@"; exit ;;
+      doctor) show_diagnostics; exit ;;
       rm|-) shift; remove_versions "$@"; exit ;;
       prune) prune_cache; exit ;;
       latest) install latest; exit ;;
       stable) install stable; exit ;;
       lts) install lts; exit ;;
-      ls|list) display_versions_paths ;;
-      lsr|ls-remote|list-remote) shift; display_remote_versions "$1" ;;
-      uninstall) uninstall_installed ;;
+      ls|list) display_versions_paths; exit ;;
+      lsr|ls-remote|list-remote) shift; display_remote_versions "$1"; exit ;;
+      uninstall) uninstall_installed; exit ;;
       i|install) shift; install "$1"; exit ;;
       *) install "$1"; exit ;;
     esac

--- a/bin/n
+++ b/bin/n
@@ -856,7 +856,7 @@ function display_remote_versions() {
   local match_count="${N_MAX_REMOTE_MATCHES}"
   if [[ -z "${version}" ]]; then
     match='.'
-  elif [[ "${version}" = "lts" ]]; then
+  elif [[ "${version}" = "lts" || "${version}" = "stable" ]]; then
     match_count=1
     # Codename is last field, first one with a name is newest lts
     match="${TAB_CHAR}[a-zA-Z]+\$"

--- a/bin/n
+++ b/bin/n
@@ -15,7 +15,25 @@ log() {
 #
 
 abort() {
-  printf "\n  ${SGR_RED}Error: %s${SGR_RESET}\n\n" "$*" && exit 1
+  >&2 printf "\n  ${SGR_RED}Error: %s${SGR_RESET}\n\n" "$*" && exit 1
+}
+
+#
+# Synopsis: trace message ...
+# Debugging output to stderr, not used in production code.
+#
+
+function trace() {
+  >&2 printf "trace: %s\n" "$*"
+}
+
+#
+# Synopsis: echo_red message ...
+# Highlight message in colour (on stdout).
+#
+
+function echo_red() {
+  printf "${SGR_RED}%s${SGR_RESET}\n" "$*"
 }
 
 #
@@ -23,8 +41,11 @@ abort() {
 #
 
 VERSION="6.0.0-0"
+
 N_PREFIX="${N_PREFIX-/usr/local}"
-BASE_VERSIONS_DIR="$N_PREFIX/n/versions"
+N_PREFIX=${N_PREFIX%/}
+readonly N_PREFIX
+readonly CACHE_DIR=$N_PREFIX/n/versions
 
 N_NODE_MIRROR=${N_NODE_MIRROR:-${NODE_MIRROR:-https://nodejs.org/dist}}
 N_NODE_MIRROR=${N_NODE_MIRROR%/}
@@ -68,6 +89,9 @@ elif [ -n "$HTTP_PASSWORD" ]; then
   abort "Must specify HTTP_USER when supplying HTTP_PASSWORD"
 fi
 
+# Set by set_active_node
+g_active_node=
+
 ACTIVATE=true
 ARCH=
 
@@ -107,6 +131,18 @@ set_arch() {
   else
     abort "missing -a|--arch value"
   fi
+}
+
+#
+# Synopsis: set_insecure
+# Globals modified:
+# - CURL_OPTIONS
+# - WGET_OPTIONS
+#
+
+function set_insecure() {
+  CURL_OPTIONS+=( "--insecure" )
+  WGET_OPTIONS+=( "--no-check-certificate" )
 }
 
 #
@@ -219,63 +255,81 @@ handle_sigtstp() {
 display_help() {
   cat <<-EOF
 
-  Usage: n [options] [COMMAND] [args]
+Usage: n [options] [COMMAND] [args]
 
-  Commands:
+Commands:
 
-    n                              Output versions installed
-    n latest                       Install or activate the latest node release
-    n -a x86 latest                As above but force 32 bit architecture
-    n lts                          Install or activate the latest LTS node release
-    n <version>                    Install node <version>
-    n use <version> [args ...]     Execute node <version> with [args ...]
-    n bin <version>                Output bin path for <version>
-    n rm <version ...>             Remove the given version(s)
-    n prune                        Remove all versions except the active version
-    n --latest                     Output the latest node version available
-    n --lts                        Output the latest LTS node version available
-    n ls                           Output the versions of node available
-    n uninstall                    Remove the installed node and npm
+  n                              Display downloaded node versions and install selection
+  n latest                       Install the latest node release (downloading if necessary)
+  n lts                          Install the latest LTS node release (downloading if necessary)
+  n <version>                    Install node <version> (downloading if necessary)
+  n run <version> [args ...]     Execute downloaded node <version> with [args ...]
+  n which <version>              Output path for downloaded node <version>
+  n exec <vers> <cmd> [args...]  Execute command with modified PATH, so downloaded node <version> and npm first
+  n rm <version ...>             Remove the given downloaded version(s)
+  n prune                        Remove all downloaded versions except the installed version
+  n --latest                     Output the latest node version available
+  n --lts                        Output the latest LTS node version available
+  n ls                           Output downloaded versions
+  n ls-remote [version]          Output matching versions available for download
+  n uninstall                    Remove the installed node and npm
 
-  Options:
+Options:
 
-    -V, --version   Output version of n
-    -h, --help      Display help information
-    -q, --quiet     Disable curl output (if available)
-    -d, --download  Download only
-    -a, --arch      Override system architecture
+  -V, --version   Output version of n
+  -h, --help      Display help information
+  -q, --quiet     Disable curl output (if available)
+  -d, --download  Download only
+  -a, --arch      Override system architecture
+  --all           ls-remote displays all matches instead of last 20
+  --insecure      Turn off certificate checking for https requests (may be needed from behind a proxy server)
 
-  Aliases:
+Aliases:
 
-    which   bin
-    use     as
-    list    ls
-    -       rm
-    stable  lts
+  which: bin
+  run: use, as
+  ls: list
+  lsr: ls-remote
+  rm: -
+  lts: stable
+  latest: current
+
+Versions:
+
+  Numeric version numbers can be complete or incomplete, with an optional leading 'v'.
+  Versions can also be specified by label, or codename,
+  and other downloadable releases by <remote-folder>/<version>
+
+    4.9.1, 8, v6.1    Numeric versions
+    lts               Newest Long Term Support official release
+    latest, current   Newest official release
+    boron, carbon     Codenames for release streams
+    and nightly, chakracore-release/latest, rc/10 et al
 
 EOF
 }
 
 err_no_installed_print_help() {
-  printf "\n  ${SGR_RED}Error: no installed version${SGR_RESET}\n"
   display_help
-  exit 1
+  abort "no downloaded versions yet, see above help for commands"
 }
 
 #
-# Output version after selected.
+# Synopsis: next_version_installed selected_version
+# Output version after selected (which may be blank under some circumstances).
 #
 
-next_version_installed() {
-  list_versions_installed | grep "$selected" -A 1 | tail -n 1
+function next_version_installed() {
+  display_cache_versions | grep "$1" -A 1 | tail -n 1
 }
 
 #
-# Output version before selected.
+# Synopsis: prev_version_installed selected_version
+# Output version before selected  (which may be blank under some circumstances).
 #
 
-prev_version_installed() {
-  list_versions_installed | grep "$selected" -B 1 | head -n 1
+function prev_version_installed() {
+  display_cache_versions | grep "$1" -B 1 | head -n 1
 }
 
 #
@@ -287,19 +341,26 @@ display_n_version() {
 }
 
 #
-# Check for installed version, and populate $active
+# Synopsis: set_active_node
+# Checks cached downloads for a binary matching the active node.
+# Globals modified:
+# - g_active_node
 #
 
-check_current_version() {
-  command -v node &> /dev/null
-  if test $? -eq 0; then
-    local current=$(node --version)
-    current=${current#v}
-    for bin in "${BINS[@]}"; do
+function set_active_node() {
+  g_active_node=
+  local node_path="$(command -v node)"
+  if [[ -x "${node_path}" ]]; then
+    local installed_version=$(node --version)
+    installed_version=${installed_version#v}
+    for dir in "${CACHE_DIR}"/*/ ; do
+      local folder_name="${dir%/}"
+      folder_name="${folder_name##*/}"
       if diff &> /dev/null \
-        "$BASE_VERSIONS_DIR/$bin/$current/bin/node" \
-        "$(command -v node)" ; then
-        active="$bin/$current"
+        "${CACHE_DIR}/${folder_name}/${installed_version}/bin/node" \
+        "${node_path}" ; then
+        g_active_node="${folder_name}/${installed_version}"
+        break
       fi
     done
   fi
@@ -309,10 +370,10 @@ check_current_version() {
 # Display sorted versions directories paths.
 #
 
-versions_paths() {
-  find "$BASE_VERSIONS_DIR" -maxdepth 2 -type d \
-    | sed 's|'"$BASE_VERSIONS_DIR"'/||g' \
-    | grep -E "/[0-9]+\.[0-9]+\.[0-9]+$" \
+display_versions_paths() {
+  find "$CACHE_DIR" -maxdepth 2 -type d \
+    | sed 's|'"$CACHE_DIR"'/||g' \
+    | grep -E "/[0-9]+\.[0-9]+\.[0-9]+" \
     | sed 's|/|.|' \
     | sort -k 1,1 -k 2,2n -k 3,3n -k 4,4n -t . \
     | sed 's|\.|/|'
@@ -325,7 +386,7 @@ versions_paths() {
 display_versions_with_selected() {
   selected="$1"
   echo
-  for version in $(versions_paths); do
+  for version in $(display_versions_paths); do
     if test "$version" = "$selected"; then
       printf "  ${SGR_CYAN}ο${SGR_RESET} %s\n" "$version"
     else
@@ -337,12 +398,12 @@ display_versions_with_selected() {
 }
 
 #
-# List installed versions.
+# Synopsis: display_cache_versions
 #
 
-list_versions_installed() {
-  for version in $(versions_paths); do
-    echo "$version"
+function display_cache_versions() {
+  for folder_and_version in $(display_versions_paths); do
+    echo "${folder_and_version}"
   done
 }
 
@@ -350,11 +411,13 @@ list_versions_installed() {
 # Display current node --version and others installed.
 #
 
-display_versions() {
+menu_select_cache_versions() {
   enter_fullscreen
-  check_current_version
+  set_active_node
+  local selected="${g_active_node}"
+
   clear
-  display_versions_with_selected "$active"
+  display_versions_with_selected "${selected}"
 
   trap handle_sigint INT
   trap handle_sigtstp SIGTSTP
@@ -374,22 +437,26 @@ display_versions() {
           case "$arrow" in
             $UP)
               clear
-              display_versions_with_selected "$(prev_version_installed)"
+              selected="$(prev_version_installed "${selected}")"
+              display_versions_with_selected "${selected}"
               ;;
             $DOWN)
               clear
-              display_versions_with_selected "$(next_version_installed)"
+              selected="$(next_version_installed "${selected}")"
+              display_versions_with_selected "${selected}"
               ;;
           esac
         fi
         ;;
       "k")
         clear
-        display_versions_with_selected "$(prev_version_installed)"
+        selected="$(prev_version_installed "${selected}")"
+        display_versions_with_selected "${selected}"
         ;;
       "j")
         clear
-        display_versions_with_selected "$(next_version_installed)"
+        selected="$(next_version_installed "${selected}")"
+        display_versions_with_selected "${selected}"
         ;;
       "q")
         clear
@@ -399,7 +466,7 @@ display_versions() {
       "")
         # enter key returns empty string
         leave_fullscreen
-        activate "$selected"
+        [[ -n "${selected}" ]] && activate "${selected}"
         exit
         ;;
     esac
@@ -412,77 +479,6 @@ display_versions() {
 
 erase_line() {
   printf "\033[1A\033[2K"
-}
-
-#
-# Check if the HEAD response of <url> is 200.
-#
-is_ok() {
-  if command -v curl > /dev/null; then
-    $GET -Is "$1" | head -n 1 | grep 200 > /dev/null
-  else
-    $GET -S --spider 2>&1 "$1" | head -n 1 | grep 200 > /dev/null
-  fi
-}
-
-#
-# Check if the OSS(Object Storage Service) mirror is ok.
-#
-is_oss_ok() {
-  if command -v curl > /dev/null; then
-    if $GET -Is $1 | head -n 1 | grep 302 > /dev/null; then
-      is_oss_ok $GET -Is $1 | grep Location | awk -F ': ' '{print $2}'
-    else
-      $GET -Is $1 | head -n 1 | grep 200 > /dev/null
-    fi
-  else
-    if $GET -S --spider 2>&1 $1 | head -n 1 | grep 302 > /dev/null; then
-      is_oss_ok $GET -S --spider 2>&1 $1 | grep Location | awk -F ': ' '{print $2}'
-    else
-      $GET -S --spider 2>&1 $1 | head -n 1 | grep 200 > /dev/null
-    fi
-  fi
-}
-
-#
-# Determine tarball url for <version>
-#
-
-tarball_url() {
-  local version=$1
-  local uname="$(uname -a)"
-  local arch=x86
-  local os=
-  local ext=gz
-
-  # from nave(1)
-  case "$uname" in
-    Linux*) os=linux ;;
-    Darwin*) os=darwin ;;
-    SunOS*) os=sunos ;;
-  esac
-
-  case "$uname" in
-    *x86_64*) arch=x64 ;;
-    *armv6l*) arch=armv6l ;;
-    *armv7l*) arch=armv7l ;;
-    *arm64*) arch=arm64 ;;
-    *aarch64*) arch=arm64 ;;
-  esac
-
-  if [ "${arch}" = "armv6l" ] && [ "${BIN_NAME[$DEFAULT]}" = node ]; then
-    local semver=${version//./ }
-    local major="$(echo "$semver" | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//')"
-    local minor="$(echo "$semver" | awk '{print $2}' | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//')"
-    [[ "$major" -eq "" && "$minor" -lt 12 ]] && arch=arm-pi
-  fi
-
-  [ -n "$ARCH" ] && arch="$ARCH"
-
-  [ -n "$N_USE_XZ" ] && ext="xz"
-
-  echo "${MIRROR[$DEFAULT]}v${version}/${BIN_NAME[$DEFAULT]}-v${version}-${os}-${arch}.tar.${ext}"
-
 }
 
 #
@@ -516,7 +512,7 @@ disable_pax_mprotect() {
 
 activate() {
   local version="$1"
-  local dir=$BASE_VERSIONS_DIR/$version
+  local dir="$CACHE_DIR/$version"
   # Remove old npm to avoid potential issues with simple overwrite.
   if test -d "$dir/lib/node_modules/npm"; then
     if test -d "$N_PREFIX/lib/node_modules/npm"; then
@@ -539,33 +535,15 @@ activate() {
     log "installed" "$("${installed_node}" --version) to ${installed_node}"
     log "active" "$("${active_node}" --version) at ${active_node}"
   else
-    log "installed" "$("${installed_node}" --version)"
+    local npm_version_str=""
+    local installed_npm="${N_PREFIX}/bin/npm"
+    local active_npm="$(command -v npm)"
+    if [[ -e "${active_npm}" && -e "${installed_npm}" && "${active_npm}" = "${installed_npm}" ]]; then
+      npm_version_str=" (with npm $(npm --version))"
+    fi
+
+    log "installed" "$("${installed_node}" --version)${npm_version_str}"
   fi
-}
-
-#
-# Install latest version.
-#
-
-install_latest() {
-  install "$(display_latest_version)"
-}
-
-#
-# Install latest stable version.
-# (See additional comments for display_latest_stable_version)
-#
-
-install_stable() {
-  install "$(display_latest_stable_version)"
-}
-
-#
-# Install latest LTS version.
-#
-
-install_lts() {
-  install "$(display_latest_lts_version)"
 }
 
 #
@@ -573,23 +551,13 @@ install_lts() {
 #
 
 install() {
-  local version=${1#v}
+  [[ -z "$1" ]] && abort "version required"
+  local version
+  version="$(display_latest_resolved_version "$1")" || return 2
+  [[ -n "${version}" ]] || abort "no version found for '$1'"
+  update_mirror_settings_for_version "$1"
 
-  local dots="${version//[^.]/}"
-  if test ${#dots} -lt 2; then
-    version="$($GET 2> /dev/null "${MIRROR[DEFAULT]}" \
-      | grep -E "</a>" \
-      | grep -E -o '[0-9]+\.[0-9]+\.[0-9]+' \
-      | grep -E -v '^0\.[0-7]\.' \
-      | grep -E -v '^0\.8\.[0-5]$' \
-      | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
-      | grep -E "^$version\." \
-      | tail -n1)"
-
-    test "$version" || abort "invalid version '${1#v}'"
-  fi
-
-  local dir="${VERSIONS_DIR[$DEFAULT]}/$version"
+  local dir="${CACHE_DIR}/${g_mirror_folder_name}/${version}"
 
   if test -n "$N_USE_XZ"; then
     local tarflag="-Jx"
@@ -600,36 +568,33 @@ install() {
   if test -d "$dir"; then
     if [[ ! -e "$dir/n.lock" ]] ; then
       if "$ACTIVATE" ; then
-        activate "${BINS[$DEFAULT]}/$version"
+        activate "${g_mirror_folder_name}/${version}"
       fi
       exit
     fi
   fi
 
   echo
-  log installing "${BINS[$DEFAULT]}-v$version"
+  log installing "${g_mirror_folder_name}-v$version"
 
   local url="$(tarball_url "$version")"
-  is_ok "$url" || is_oss_ok "$url" || abort "invalid version '$version'"
+  is_ok "${url}" || abort "download preflight failed for '$version' (${url})"
 
   log mkdir "$dir"
-  if ! mkdir -p "$dir"; then
-    abort "sudo required"
-  else
-    touch "$dir/n.lock"
-  fi
+  mkdir -p "$dir" || abort "sudo required (or change ownership, or define N_PREFIX)"
+  touch "$dir/n.lock"
 
-  cd "$dir"
+  cd "${dir}" || abort "Failed to cd to ${dir}"
 
   log fetch "$url"
-  $GET "$url" | tar "$tarflag" --strip-components=1
+  do_get "${url}" | tar "$tarflag" --strip-components=1
   [ "$GET_SHOWS_PROGRESS" = "true" ] && erase_line
   rm -f "$dir/n.lock"
 
   disable_pax_mprotect bin/node
 
   if "$ACTIVATE" ; then
-    activate "${BINS[$DEFAULT]}/$version"
+    activate "${g_mirror_folder_name}/$version"
   fi
   echo
 }
@@ -640,6 +605,21 @@ install() {
 
 set_quiet() {
   command -v curl > /dev/null && CURL_OPTIONS+=( "--silent" ) && GET_SHOWS_PROGRESS="false"
+}
+
+#
+# Synopsis: do_get [option...] url
+# Call curl or wget with combination of global and passed options.
+#
+
+function do_get() {
+  if command -v curl &> /dev/null; then
+    curl "${CURL_OPTIONS[@]}" "$@"
+  elif command -v wget &> /dev/null; then
+    wget "${WGET_OPTIONS[@]}" "$@"
+  else
+    abort "curl or wget command required"
+  fi
 }
 
 #
@@ -660,164 +640,106 @@ function do_get_index() {
 }
 
 #
-# Remove <version ...>
+# Synopsis: remove_versions version ...
 #
 
-remove_versions() {
-  test -z "$1" && abort "version(s) required"
-  while test $# -ne 0; do
-    local version=${1#v}
-    rm -rf "${VERSIONS_DIR[$DEFAULT]}/$version"
+function remove_versions() {
+  [[ -z "$1" ]] && abort "version(s) required"
+  while [[ $# -ne 0 ]]; do
+    local version
+    version="$(display_latest_resolved_version "$1")" || break
+    if [[ -n "${version}" ]]; then
+      update_mirror_settings_for_version "$1"
+      local dir="${CACHE_DIR}/${g_mirror_folder_name}/${version}"
+      if [[ -s "${dir}" ]]; then
+        rm -rf "${dir}"
+      else
+        echo "$1 (${version}) not in downloads cache"
+      fi
+    else
+      echo "No version found for '$1'"
+    fi
     shift
   done
 }
 
 #
-# Prune non-active versions
+# Synopsis: prune_cache
 #
 
-prune_versions() {
-  check_current_version
-  for version in $(versions_paths); do
-    if [ "$version" != "$active" ]
-    then
-      echo "$version"
-      rm -rf "${BASE_VERSIONS_DIR[$DEFAULT]}/$version"
+function prune_cache() {
+  set_active_node
+
+  for folder_and_version in $(display_versions_paths); do
+    if [[ "${folder_and_version}" != "${g_active_node}" ]]; then
+      echo "${folder_and_version}"
+      rm -rf "${CACHE_DIR:?}/${folder_and_version}"
     fi
   done
 }
 
 #
-# Output bin path for <version>
+# Synopsis: find_cached_version version
+# Finds cache directory for resolved version.
+# Globals modified:
+# - g_cached_version
+
+function find_cached_version() {
+  [[ -z "$1" ]] && abort "version required"
+  local version
+  version="$(display_latest_resolved_version "$1")" || exit 1
+  [[ -n "${version}" ]] || abort "no version found for '$1'"
+
+  update_mirror_settings_for_version "$1"
+  g_cached_version="${CACHE_DIR}/${g_mirror_folder_name}/${version}"
+  [[ -d "${g_cached_version}" ]] || abort "'$1' (${version}) not in downloads cache"
+}
+
+
+#
+# Synopsis: display_bin_path_for_version version
 #
 
-display_bin_path_for_version() {
-  test -z "$1" && abort "version required"
-  local version=${1#v}
+function display_bin_path_for_version() {
+  find_cached_version "$1"
+  echo "${g_cached_version}/bin/node"
+}
 
-  if [ "$version" = "latest" ]; then
-    version="$(display_latest_version)"
-  fi
+#
+# Synopsis: run_with_version version [args...]
+# Run the given <version> of node with [args ..]
+#
 
-  if [ "$version" = "stable" ]; then
-    version="$(display_latest_stable_version)"
-  fi
+function run_with_version() {
+  find_cached_version "$1"
+  shift # remove version from parameters
+  exec "${g_cached_version}/bin/node" "$@"
+}
 
-  if [ "$version" = "lts" ]; then
-    version="$(display_latest_lts_version)"
-  fi
+#
+# Synopsis: exec_with_version <version> command [args...]
+# Modify the path to include <version> and execute command.
+#
 
-  local bin="${VERSIONS_DIR[$DEFAULT]}/$version/bin/node"
-  if test -f "$bin"; then
-    printf "%s\n" "$bin"
+function exec_with_version() {
+  find_cached_version "$1"
+  shift # remove version from parameters
+  PATH="${g_cached_version}/bin:$PATH" exec "$@"
+}
+
+#
+# Synopsis: is_ok url
+# Check the HEAD response of <url>.
+#
+
+function is_ok() {
+  # Note: both curl and wget can follow redirects, as present on some mirrors (e.g. https://npm.taobao.org/mirrors/node).
+  # The output is complicated with redirects, so keep it simple and use command status rather than parse output.
+  if command -v curl &> /dev/null; then
+    do_get --silent --head "$1" > /dev/null || return 1
   else
-    abort "'$1' is not installed"
+    do_get --spider "$1" &> /dev/null || return 1
   fi
-}
-
-#
-# Execute the given <version> of node with [args ...]
-#
-
-execute_with_version() {
-  test -z "$1" && abort "version required"
-  local version=${1#v}
-
-  if [ "$version" = "latest" ]; then
-    version="$(display_latest_version)"
-  fi
-
-  if [ "$version" = "stable" ]; then
-    version="$(display_latest_stable_version)"
-  fi
-
-  if [ "$version" = "lts" ]; then
-    version="$(display_latest_lts_version)"
-  fi
-
-  local bin="${VERSIONS_DIR[$DEFAULT]}/$version/bin/node"
-
-  shift # remove version
-
-  if test -f "$bin"; then
-    exec "$bin" "$@"
-  else
-    abort "'$version' is not installed"
-  fi
-}
-
-#
-# Display the latest release version.
-#
-
-display_latest_version() {
-  $GET 2> /dev/null "${MIRROR[$DEFAULT]}" \
-    | grep -E "</a>" \
-    | grep -E -o '[0-9]+\.[0-9]+\.[0-9]+' \
-    | grep -E -v '^0\.[0-7]\.' \
-    | grep -E -v '^0\.8\.[0-5]$' \
-    | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
-    | tail -n1
-}
-
-#
-# Display the latest stable release version.
-# Note: Stable is no longer used by nodejs to identify versions,
-# so this could be considered deprecated. To avoid breaking
-# existing usages and minimise code churn in meantime,
-# return the lts version.
-# lts is the version recommended for most users.
-#
-
-display_latest_stable_version() {
-  display_latest_lts_version
-}
-
-#
-# Display the latest lts release version.
-#
-
-display_latest_lts_version() {
-  local folder_name="$($GET 2> /dev/null "${MIRROR[$DEFAULT]}" \
-    | grep -E "</a>" \
-    | grep -E -o 'latest-[a-z]{2,}' \
-    | sort \
-    | tail -n1)"
-
-  $GET 2> /dev/null "${MIRROR[$DEFAULT]}/$folder_name/" \
-    | grep -E "</a>" \
-    | grep -E -o '[0-9]+\.[0-9]+\.[0-9]+' \
-    | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
-    | tail -n1
-}
-
-#
-# Display the versions available.
-#
-
-display_remote_versions() {
-  check_current_version
-  local versions=""
-  versions="$($GET 2> /dev/null "${MIRROR[$DEFAULT]}" \
-    | grep -E "</a>" \
-    | grep -E -o '[0-9]+\.[0-9]+\.[0-9]+' \
-    | sort -u -k 1,1n -k 2,2n -k 3,3n -t . \
-    | awk '{ print "  " $1 }')"
-
-  echo
-  local bin="${BINS[$DEFAULT]}"
-  for v in $versions; do
-    if test "$active" = "$bin/$v"; then
-      printf "  ${SGR_CYAN}ο${SGR_RESET} %s\n" "$v"
-    else
-      if test -d "$BASE_VERSIONS_DIR/$bin/$v"; then
-        printf "    %s\n" "$v"
-      else
-        printf "    ${SGR_FAINT}%s${SGR_RESET}\n" "$v"
-      fi
-    fi
-  done
-  echo
 }
 
 #
@@ -850,6 +772,7 @@ function display_tarball_platform() {
       ;;
   esac
   # (arch unlikely to be right for SunOS and AIX. Investigate further if/when anyone asks!)
+  [ -n "$ARCH" ] && arch="$ARCH"
 
   echo "${os}-${arch}"
 }
@@ -865,6 +788,33 @@ function display_compatible_file_field {
     compatible_file_field="osx-${BASH_REMATCH[1]}-tar"
   fi
   echo "${compatible_file_field}"
+}
+
+#
+# Synopsis: tarball_url version
+#
+
+function tarball_url() {
+  local version="$1"
+  local ext=gz
+  [ -n "$N_USE_XZ" ] && ext="xz"
+  echo "${g_mirror_url}/v${version}/node-v${version}-$(display_tarball_platform).tar.${ext}"
+}
+
+#
+# Synopsis: display_latest_resolved_version version
+#
+
+function display_latest_resolved_version() {
+  local version=${1#node/}
+  if is_exact_numeric_version "${version}"; then
+    # Just numbers, already resolved, no need to lookup first.
+    version="${version#v}"
+    echo "${version}"
+  else
+    # Complicated recognising exact version, KISS and awlays lookup for now.
+    N_MAX_REMOTE_MATCHES=1 display_remote_versions "$1"
+  fi
 }
 
 #
@@ -899,7 +849,7 @@ function display_match_limit(){
 # Synopsis: display_remote_versions version
 #
 
-function display_remote_versions2() {
+function display_remote_versions() {
   local version="$1"
   update_mirror_settings_for_version "${version}"
   local match='.'
@@ -1007,33 +957,222 @@ uninstall_installed() {
 }
 
 #
+# Synopsis: show_permission_suggestions
+#
+
+function show_permission_suggestions() {
+  echo "Suggestions:"
+  echo "- run n with sudo, or"
+  echo "- define N_PREFIX to a writeable location, or"
+}
+
+#
+# Synopsis: show_diagnostics
+# Show environment and check for common problems.
+#
+
+function show_diagnostics() {
+  echo "This information is to help you diagnose issues, and useful when reporting an issue."
+  echo "Note: some output may contain passwords. Redact before sharing."
+
+  printf "\n\n# Command Locations and Versions\n"
+
+  printf "\n## bash\n"
+  command -v bash && bash --version
+
+  printf "\n## n\n"
+  command -v n && n --version
+
+  printf "\n## node\n"
+  if command -v node &> /dev/null; then
+    command -v node && node --version
+    node -e 'if (process.versions.v8) console.log("JavaScript engine: v8"); if (process.versions.chakracore) console.log("JavaScript engine: chakracore")'
+
+    printf "\n## npm\n"
+    command -v npm && npm --version
+  fi
+
+  printf "\n## tar\n"
+  if command -v tar &> /dev/null; then
+    command -v tar && tar --version
+  else
+    echo_red "tar not found. Needed for extracting downloads."
+  fi
+
+  printf "\n## curl or wget\n"
+  if command -v curl &> /dev/null; then
+    command -v curl && curl --version
+  elif command -v wget &> /dev/null; then
+    command -v wget && wget --version
+  else
+    echo_red "Neither curl nor wget found. Need one of them for downloads."
+  fi
+
+  printf "\n## uname\n"
+  uname -a
+
+
+  printf "\n\n# Settings\n"
+
+  printf "\n\n## n\n"
+  echo "node mirror: ${N_NODE_MIRROR}"
+  echo "node downloads mirror: ${N_NODE_DOWNLOAD_MIRROR}"
+  echo "install destination: ${N_PREFIX}"
+  [[ -n "${N_PREFIX}" ]] && echo "PATH: ${PATH}"
+  echo "ls-remote max matches: ${N_MAX_REMOTE_MATCHES}"
+
+  printf "\n\n## Proxy\n"
+  # disable "var is referenced but not assigned": https://github.com/koalaman/shellcheck/wiki/SC2154
+  # shellcheck disable=SC2154
+  [[ -n "${http_proxy}" ]] && echo "http_proxy: ${http_proxy}"
+  # shellcheck disable=SC2154
+  [[ -n "${https_proxy}" ]] && echo "https_proxy: ${https_proxy}"
+  if command -v curl &> /dev/null; then
+    # curl supports lower case and upper case!
+    # shellcheck disable=SC2154
+    [[ -n "${all_proxy}" ]] && echo "all_proxy: ${all_proxy}"
+    [[ -n "${ALL_PROXY}" ]] && echo "ALL_PROXY: ${ALL_PROXY}"
+    [[ -n "${HTTP_PROXY}" ]] && echo "HTTP_PROXY: ${HTTP_PROXY}"
+    [[ -n "${HTTPS_PROXY}" ]] && echo "HTTPS_PROXY: ${HTTPS_PROXY}"
+    if [[ -e "${CURL_HOME}/.curlrc" ]]; then
+       echo "have \$CURL_HOME/.curlrc"
+    elif [[ -e "${HOME}/.curlrc" ]]; then
+      echo "have \$HOME/.curlrc"
+    fi
+  elif command -v wget &> /dev/null; then
+    if [[ -e "${WGETRC}" ]]; then
+      echo "have \$WGETRC"
+    elif [[ -e "${HOME}/.wgetrc" ]]; then
+      echo "have \$HOME/.wgetrc"
+    fi
+  fi
+
+  printf "\n\n# Checks\n"
+
+  printf "\nChecking n install destination is in PATH...\n"
+  local install_bin="${N_PREFIX}/bin"
+  local path_wth_guards=":${PATH}:"
+  if [[ "${path_wth_guards}" =~ :${install_bin}/?: ]]; then
+    printf "good\n"
+  else
+    echo_red "'${install_bin}' is not in PATH"
+  fi
+  if command -v node &> /dev/null; then
+    printf "\nChecking n install destination priority in PATH...\n"
+    local node_dir="$(dirname "$(command -v node)")"
+
+    local index=0
+    local path_entry
+    local path_entries
+    local install_bin_index=0
+    local node_index=999
+    IFS=':' read -ra path_entries <<< "${PATH}"
+    for path_entry in "${path_entries[@]}"; do
+      (( index++ ))
+      [[ "${path_entry}" =~ ^${node_dir}/?$ ]] && node_index="${index}"
+      [[ "${path_entry}" =~ ^${install_bin}/?$ ]] && install_bin_index="${index}"
+    done
+    if [[ "${node_index}" -lt "${install_bin_index}" ]]; then
+      echo_red "There is a version of node installed which will be found in PATH before the n installed version."
+    else
+      printf "good\n"
+    fi
+  fi
+
+  printf "\nChecking permissions for cache folder...\n"
+  # Most likely problem is ownership rather than than permissions as such.
+  local cache_root="${N_PREFIX}/n"
+  if [[ -e "${N_PREFIX}" && ! -w "${N_PREFIX}" && ! -e "${cache_root}" ]]; then
+    echo_red "You do not have write permission to create: ${cache_root}"
+    show_permission_suggestions
+    echo "- make a folder you own:"
+    echo "      sudo mkdir -p \"${cache_root}\""
+    echo "      sudo chown $(whoami) \"${cache_root}\""
+  elif [[ -e "${cache_root}" && ! -w "${cache_root}" ]]; then
+    echo_red "You do not have write permission to: ${cache_root}"
+    show_permission_suggestions
+    echo "- change folder ownership to yourself:"
+    echo "      sudo chown -R $(whoami) \"${cache_root}\""
+  elif [[ ! -e "${cache_root}" ]]; then
+    echo "Cache folder does not exist: ${cache_root}"
+    echo "This is normal if you have not done an install yet, as cache is only created when needed."
+  elif [[ -e "${CACHE_DIR}" && ! -w "${CACHE_DIR}" ]]; then
+    echo_red "You do not have write permission to: ${CACHE_DIR}"
+    show_permission_suggestions
+    echo "- change folder ownership to yourself:"
+    echo "      sudo chown -R $(whoami) \"${CACHE_DIR}\""
+  else
+    echo "good"
+  fi
+
+  if [[ -e "${N_PREFIX}" ]]; then
+    # Most likely problem is ownership rather than than permissions as such.
+    printf "\nChecking permissions for install folders...\n"
+    local install_writeable="true"
+    for subdir in bin lib include share; do
+      if [[ -e "${N_PREFIX}/${subdir}" && ! -w "${N_PREFIX}/${subdir}" ]]; then
+        install_writeable="false"
+        echo_red "You do not have write permission to: ${N_PREFIX}/${subdir}"
+        break
+      fi
+    done
+    if [[ "${install_writeable}" = "true" ]]; then
+      echo "good"
+    else
+      show_permission_suggestions
+      echo "- change folder ownerships to yourself:"
+      echo "      (cd \"${N_PREFIX}\" && sudo chown -R $(whoami) bin lib include share)"
+    fi
+  fi
+
+  printf "\nChecking mirror is reachable...\n"
+  if is_ok "${N_NODE_MIRROR}/"; then
+    printf "good\n"
+  else
+    echo_red "mirror not reachable"
+    printf "Showing failing command and output\n"
+    if command -v curl &> /dev/null; then
+      ( set -x; do_get --head "${N_NODE_MIRROR}/" )
+    else
+      ( set -x; do_get --spider "${N_NODE_MIRROR}/" )
+    printf "\n"
+   fi
+  fi
+}
+
+#
 # Handle arguments.
 #
 
 if test $# -eq 0; then
-  test -z "$(versions_paths)" && err_no_installed_print_help
-  display_versions
+  test -z "$(display_versions_paths)" && err_no_installed_print_help
+  menu_select_cache_versions
 else
   while test $# -ne 0; do
     case "$1" in
+      --all) N_MAX_REMOTE_MATCHES=32000 ;;
       -V|--version) display_n_version ;;
       -h|--help|help) display_help; exit ;;
       -q|--quiet) set_quiet ;;
       -d|--download) ACTIVATE=false ;;
-      --latest) display_latest_version; exit ;;
-      --stable) display_latest_stable_version; exit ;;
-      --lts) NVH_MAX_REMOTE_MATCHES=1 display_remote_versions2 lts; exit ;;
+      --insecure) set_insecure ;;
+      --latest) display_remote_versions latest; exit ;;
+      --stable) display_remote_versions lts; exit ;; # [sic] old terminology
+      --lts) display_remote_versions lts; exit ;;
       -a|--arch) shift; set_arch "$1";; # set arch and continue
       bin|which) display_bin_path_for_version "$2"; exit ;;
-      as|use) shift; execute_with_version "$@"; exit ;;
+      run|as|use) shift; run_with_version "$@"; exit ;;
+      exec) shift; exec_with_version "$@" ;;
+      doctor) show_diagnostics ;;
       rm|-) shift; remove_versions "$@"; exit ;;
-      prune) prune_versions; exit ;;
-      latest) install_latest; exit ;;
-      stable) install_stable; exit ;;
-      lts) install_lts; exit ;;
-      ls|list) display_remote_versions; exit ;;
-      lsr|ls-remote|list-remote) shift; display_remote_versions2 "$1" ;;
+      prune) prune_cache; exit ;;
+      latest) install latest; exit ;;
+      stable) install stable; exit ;;
+      lts) install lts; exit ;;
+      ls|list) display_versions_paths ;;
+      lsr|ls-remote|list-remote) shift; display_remote_versions "$1" ;;
       uninstall) uninstall_installed ;;
+      i|install) shift; install "$1"; exit ;;
       *) install "$1"; exit ;;
     esac
     shift

--- a/bin/n
+++ b/bin/n
@@ -40,7 +40,7 @@ function echo_red() {
 # Setup and state
 #
 
-VERSION="6.0.0-0"
+VERSION="6.0.0-1"
 
 N_PREFIX="${N_PREFIX-/usr/local}"
 N_PREFIX=${N_PREFIX%/}

--- a/bin/n
+++ b/bin/n
@@ -3,14 +3,6 @@
 # Disabled "Declare and assign separately to avoid masking return values": https://github.com/koalaman/shellcheck/wiki/SC2155
 
 #
-# Setup.
-#
-
-VERSION="5.0.3-0"
-N_PREFIX="${N_PREFIX-/usr/local}"
-BASE_VERSIONS_DIR="$N_PREFIX/n/versions"
-
-#
 # Log <type> <msg>
 #
 
@@ -27,65 +19,55 @@ abort() {
 }
 
 #
-# All Bin (node+custom) configurations
+# Setup and state
 #
 
-BINS=("node")
-MIRROR=("${NODE_MIRROR-https://nodejs.org/dist/}")
-BIN_NAME=("node")
-VERSIONS_DIR=("$BASE_VERSIONS_DIR/node")
+VERSION="6.0.0-0"
+N_PREFIX="${N_PREFIX-/usr/local}"
+BASE_VERSIONS_DIR="$N_PREFIX/n/versions"
 
-if [ -n "$PROJECT_NAME" ]; then
-  BINS+=("$PROJECT_NAME")
-  BIN_NAME+=("$PROJECT_NAME")
-  if [ -z "$PROJECT_URL" ]; then
-    abort "Must specify PROJECT_URL when supplying PROJECT_NAME"
-  fi
-  MIRROR+=("${PROJECT_URL}")
-  VERSIONS_DIR+=("$BASE_VERSIONS_DIR/$PROJECT_NAME")
+N_NODE_MIRROR=${N_NODE_MIRROR:-${NODE_MIRROR:-https://nodejs.org/dist}}
+N_NODE_MIRROR=${N_NODE_MIRROR%/}
+readonly N_NODE_MIRROR
+
+N_NODE_DOWNLOAD_MIRROR=${N_NODE_DOWNLOAD_MIRROR:-https://nodejs.org/download}
+N_NODE_DOWNLOAD_MIRROR=${N_NODE_DOWNLOAD_MIRROR%/}
+readonly N_NODE_DOWNLOAD_MIRROR
+
+N_MAX_REMOTE_MATCHES=${N_MAX_REMOTE_MATCHES:-20}
+# modified by update_mirror_settings_for_version
+g_mirror_url=${N_NODE_MIRROR}
+g_mirror_folder_name="node"
+
+# Options for curl and wget.
+# Defining commands in variables is fraught (http://mywiki.wooledge.org/BashFAQ/050)
+# but we can follow the simple case and store arguments in an array.
+
+GET_SHOWS_PROGRESS="false"
+# --location to follow redirects
+# --fail to avoid happily downloading error page from web server for 404 et al
+# --show-error to show why failed (on stderr)
+CURL_OPTIONS=( "--location" "--fail" "--show-error" )
+if [[ -t 1 ]]; then
+  CURL_OPTIONS+=( "--progress-bar" )
+  command -v curl &> /dev/null && GET_SHOWS_PROGRESS="true"
+else
+  CURL_OPTIONS+=( "--silent" )
 fi
+WGET_OPTIONS=( "-q" "-O-" )
 
-#
-# Ensure we have curl or wget support.
-#
-
-CURL_PARAMS=( "-L"
-              "-#")
-
-WGET_PARAMS=( "--no-check-certificate"
-              "-q"
-              "-O-")
-
+# Legacy support using unprefixed env. No longer documented in README.
 if [ -n "$HTTP_USER" ];then
   if [ -z "$HTTP_PASSWORD" ]; then
     abort "Must specify HTTP_PASSWORD when supplying HTTP_USER"
   fi
-  CURL_PARAMS+=("-u $HTTP_USER:$HTTP_PASSWORD")
-  WGET_PARAMS+=("--http-password=$HTTP_PASSWORD"
+  CURL_OPTIONS+=("-u $HTTP_USER:$HTTP_PASSWORD")
+  WGET_OPTIONS+=("--http-password=$HTTP_PASSWORD"
                 "--http-user=$HTTP_USER")
 elif [ -n "$HTTP_PASSWORD" ]; then
   abort "Must specify HTTP_USER when supplying HTTP_PASSWORD"
 fi
 
-GET=
-
-# wget support
-command -v wget > /dev/null && GET="wget ${WGET_PARAMS[*]}"
-
-command -v curl > /dev/null && GET="curl ${CURL_PARAMS[*]}" && QUIET=false
-
-test -z "$GET" && abort "curl or wget required"
-
-#
-# State
-#
-
-DEFAULT=0
-if [[ -t 1 ]]; then
-  QUIET=false
-else
-  QUIET=true
-fi
 ACTIVATE=true
 ARCH=
 
@@ -128,6 +110,77 @@ set_arch() {
 }
 
 #
+# Synopsis: update_mirror_settings_for_version version
+# e.g. <nightly/latest> means using download mirror and folder is nightly
+# Globals modified:
+# - g_mirror_url
+# - g_mirror_folder_name
+#
+
+function update_mirror_settings_for_version() {
+  if is_download_folder "$1" ; then
+    g_mirror_folder_name="$1"
+    g_mirror_url="${N_NODE_DOWNLOAD_MIRROR}/${g_mirror_folder_name}"
+  elif is_download_version "$1"; then
+    [[ "$1" =~ ^([^/]+)/(.*) ]]
+    local remote_folder="${BASH_REMATCH[1]}"
+    g_mirror_folder_name="${remote_folder}"
+    g_mirror_url="${N_NODE_DOWNLOAD_MIRROR}/${g_mirror_folder_name}"
+  fi
+}
+
+#
+# Synopsis: is_lts_codename version
+#
+
+function is_lts_codename() {
+  # https://github.com/nodejs/Release/blob/master/CODENAMES.md
+  # e.g. argon, Boron
+  [[ "$1" =~ ^([Aa]rgon|[Bb]oron|[Cc]arbon|[Dd]ubnium|[Ee]rbium|[Ff]ermium|[Gg]allium|[Hh]ydrogen|[Ii]ron)$ ]]
+}
+
+#
+# Synopsis: is_download_folder version
+#
+
+function is_download_folder() {
+  # e.g. nightly
+  [[ "$1" =~ ^(chakracore-nightly|chakracore-rc|chakracore-release|next-nightly|nightly|rc|release|test|v8-canary)$ ]]
+}
+
+#
+# Synopsis: is_download_version version
+#
+
+function is_download_version() {
+  # e.g. nightly/, nightly/latest, nightly/v11
+  if [[ "$1" =~ ^([^/]+)/(.*) ]]; then
+    local remote_folder="${BASH_REMATCH[1]}"
+    is_download_folder "${remote_folder}"
+    return
+  fi
+  return 2
+}
+
+#
+# Synopsis: is_numeric_version version
+#
+
+function is_numeric_version() {
+  # e.g. 6, v7.1, 8.11.3
+  [[ "$1" =~ ^[v]{0,1}[0-9]+(\.[0-9]+){0,2}$ ]]
+}
+
+#
+# Synopsis: is_exact_numeric_version version
+#
+
+function is_exact_numeric_version() {
+  # e.g. 6, v7.1, 8.11.3
+  [[ "$1" =~ ^[v]{0,1}[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+#
 # Functions used when showing versions installed
 #
 
@@ -166,11 +219,7 @@ handle_sigtstp() {
 display_help() {
   cat <<-EOF
 
-  Usage: n [options/env] [COMMAND] [args]
-
-  Environments:
-    n [COMMAND] [args]            Uses default env (node)
-    n project [COMMAND]           Uses custom env-variables to use non-official sources
+  Usage: n [options] [COMMAND] [args]
 
   Commands:
 
@@ -245,9 +294,6 @@ check_current_version() {
   command -v node &> /dev/null
   if test $? -eq 0; then
     local current=$(node --version)
-    if [ -n "$PROJECT_VERSION_CHECK" ]; then
-      current="$(node -p "$PROJECT_VERSION_CHECK || process.exit(1)" || node --version)"
-    fi
     current=${current#v}
     for bin in "${BINS[@]}"; do
       if diff &> /dev/null \
@@ -577,7 +623,7 @@ install() {
 
   log fetch "$url"
   $GET "$url" | tar "$tarflag" --strip-components=1
-  [ "$QUIET" == false ] && erase_line
+  [ "$GET_SHOWS_PROGRESS" = "true" ] && erase_line
   rm -f "$dir/n.lock"
 
   disable_pax_mprotect bin/node
@@ -593,7 +639,24 @@ install() {
 #
 
 set_quiet() {
-  command -v curl > /dev/null && GET="$GET -s" && QUIET=true
+  command -v curl > /dev/null && CURL_OPTIONS+=( "--silent" ) && GET_SHOWS_PROGRESS="false"
+}
+
+#
+# Synopsis: do_get_index [option...] url
+# Call curl or wget with combination of global and passed options,
+# with options tweaked to be more suitable for getting index.
+#
+
+function do_get_index() {
+  if command -v curl &> /dev/null; then
+    # --silent to suppress progress et al
+    curl --silent --compressed "${CURL_OPTIONS[@]}" "$@"
+  elif command -v wget &> /dev/null; then
+    wget "${WGET_OPTIONS[@]}" "$@"
+  else
+    abort "curl or wget command required"
+  fi
 }
 
 #
@@ -758,6 +821,146 @@ display_remote_versions() {
 }
 
 #
+# Synopsis: display_tarball_platform
+#
+
+function display_tarball_platform() {
+  # https://en.wikipedia.org/wiki/Uname
+
+  local os="unexpected_os"
+  local uname_a="$(uname -a)"
+  case "${uname_a}" in
+    Linux*) os="linux" ;;
+    Darwin*) os="darwin" ;;
+    SunOS*) os="sunos" ;;
+    AIX*) os="aix" ;;
+    CYGWIN*) >&2 echo_red "Cygwin is not supported by n" ;;
+    MINGW*) >&2 echo_red "Git BASH (MSYS) is not supported by n" ;;
+  esac
+
+  local arch="unexpected_arch"
+  local uname_m="$(uname -m)"
+  case "${uname_m}" in
+    x86_64) arch=x64 ;;
+    i386 | i686) arch="x86" ;;
+    aarch64) arch=arm64 ;;
+    *)
+      # e.g. armv6l, armv7l, arm64
+      arch="${uname_m}"
+      ;;
+  esac
+  # (arch unlikely to be right for SunOS and AIX. Investigate further if/when anyone asks!)
+
+  echo "${os}-${arch}"
+}
+
+#
+# Synopsis: display_compatible_file_field
+# display <file> for current platform, as per <file> field in index.tab, which is different than actual download
+#
+
+function display_compatible_file_field {
+  local compatible_file_field="$(display_tarball_platform)"
+  if [[ "${compatible_file_field}" =~ darwin-(.*) ]]; then
+    compatible_file_field="osx-${BASH_REMATCH[1]}-tar"
+  fi
+  echo "${compatible_file_field}"
+}
+
+#
+# Synopsis: display_remote_index
+# index.tab reference: https://github.com/nodejs/nodejs-dist-indexer
+# Index fields are: version	date	files	npm	v8	uv	zlib	openssl	modules	lts security
+# KISS and just return fields we currently care about: version files lts
+#
+
+display_remote_index() {
+  local index_url="${g_mirror_url}/index.tab"
+  echo "index_url is ${index_url}"
+  # tail to remove header line
+  do_get_index "${index_url}" | tail -n +2 | cut -f 1,3,10
+  if [[ "${PIPESTATUS[0]}" -ne 0 ]]; then
+    # Reminder: abort will only exit subshell, but consistent error display
+    abort "failed to download version index (${index_url})"
+  fi
+}
+
+#
+# Synopsis: display_match_limit limit
+#
+
+function display_match_limit(){
+  if [[ "$1" -gt 1 && "$1" -lt 32000 ]]; then
+    echo "Listing remote... Displaying $1 matches (use --all to see all)."
+  fi
+}
+
+#
+# Synopsis: display_remote_versions version
+#
+
+function display_remote_versions2() {
+  local version="$1"
+  update_mirror_settings_for_version "${version}"
+  local match='.'
+  local match_count="${N_MAX_REMOTE_MATCHES}"
+  if [[ -z "${version}" ]]; then
+    match='.'
+  elif [[ "${version}" = "lts" ]]; then
+    match_count=1
+    # Codename is last field, first one with a name is newest lts
+    match="${TAB_CHAR}[a-zA-Z]+\$"
+  elif [[ "${version}" = "latest" || "${version}" = "current" ]]; then
+    match_count=1
+    match='.'
+  elif is_numeric_version "${version}"; then
+    version="v${version#v}"
+    # Avoid restriction message if exact version
+    is_exact_numeric_version "${version}" && match_count=1
+    # Quote any dots in version so they are literal for expression
+    match="${version//\./\.}"
+    # Avoid 1.2 matching 1.23
+    match="^${match}[^0-9]"
+  elif is_lts_codename "${version}"; then
+    # Capitalise (could alternatively make grep case insensitive)
+    codename="$(echo "${version:0:1}" | tr '[:lower:]' '[:upper:]')${version:1}"
+    # Codename is last field
+    match="${TAB_CHAR}${codename}\$"
+  elif is_download_folder "${version}"; then
+    match='.'
+  elif is_download_version "${version}"; then
+    version="${version#${g_mirror_folder_name}/}"
+    if [[ "${version}" = "latest" || "${version}" = "current" ]]; then
+      match_count=1
+      match='.'
+    else
+      version="v${version#v}"
+      match="${version//\./\.}"
+      match="^${match}" # prefix
+      if is_numeric_version "${version}"; then
+        # Exact numeric match
+        match="${match}[^0-9]"
+      fi
+    fi
+  else
+    abort "invalid version '$1'"
+  fi
+  display_match_limit "${match_count}"
+
+  # Implementation notes:
+  # - using awk rather than head so do not close pipe early on curl
+  # - restrict search to compatible files as not always available, or not at same time
+  # - return status of curl command (i.e. PIPESTATUS[0])
+  display_remote_index \
+    | grep -E "$(display_compatible_file_field)" \
+    | grep -E "${match}" \
+    | awk "NR<=${match_count}" \
+    | cut -f 1 \
+    | grep -E -o '[^v].*'
+  return "${PIPESTATUS[0]}"
+}
+
+#
 # Synopsis: delete_with_echo target
 #
 
@@ -807,8 +1010,6 @@ uninstall_installed() {
 # Handle arguments.
 #
 
-[[ "${QUIET}" = "true" ]] && set_quiet
-
 if test $# -eq 0; then
   test -z "$(versions_paths)" && err_no_installed_print_help
   display_versions
@@ -821,8 +1022,7 @@ else
       -d|--download) ACTIVATE=false ;;
       --latest) display_latest_version; exit ;;
       --stable) display_latest_stable_version; exit ;;
-      --lts) display_latest_lts_version; exit ;;
-      project) DEFAULT=1 ;;
+      --lts) NVH_MAX_REMOTE_MATCHES=1 display_remote_versions2 lts; exit ;;
       -a|--arch) shift; set_arch "$1";; # set arch and continue
       bin|which) display_bin_path_for_version "$2"; exit ;;
       as|use) shift; execute_with_version "$@"; exit ;;
@@ -832,6 +1032,7 @@ else
       stable) install_stable; exit ;;
       lts) install_lts; exit ;;
       ls|list) display_remote_versions; exit ;;
+      lsr|ls-remote|list-remote) shift; display_remote_versions2 "$1" ;;
       uninstall) uninstall_installed ;;
       *) install "$1"; exit ;;
     esac

--- a/docs/proxy-server.md
+++ b/docs/proxy-server.md
@@ -1,0 +1,94 @@
+# Proxy Server
+
+Under the hood, `n` uses `curl` or `wget` for the downloads. `curl` is used if available, and `wget` otherwise. Both `curl` and `wget` support using environment variables or startup files to set up the proxy.
+
+## Using Environment Variable
+
+You can define the proxy server using an environment variable, which is read by multiple commands including `curl` and `wget`:
+
+    export https_proxy='http://host:port/path'
+
+If your proxy requires authentication you can [url-encode](https://urlencode.org) the username and password in the URL. e.g.
+
+    export https_proxy='http://user:password@host:port/path'
+
+If you have defined a custom node mirror which uses http, then you would define `http_proxy` rather than `https_proxy`.
+
+## Certificate Checks
+
+Your proxy server may supply its own ssl certificates for remote sites (as a man-in-the-middle). If you can not arrange to trust the proxy in this role, you can turn off (all) certificate checking with `--insecure`. e.g.
+
+    n --insecure --lts
+
+Another possible work-around for certificate problems is to use plain http by specifying a custom node mirror:
+
+    export NODE_MIRROR='http://nodejs.org/dist'
+    export http_proxy='http://host:port/path'
+    n --lts
+
+## Startup Files
+
+An alternative to using an environment variable for the proxy settings is to configure a startup file for the command.
+
+Example `~/.curlrc` ([documentation](https://ec.haxx.se/cmdline-configfile.html))
+
+    proxy = http://host:port/path
+    proxy-user = user:password
+    # If need to disable certificate checks
+    --insecure
+
+Example `~/.wgetrc` ([documentation](https://www.gnu.org/software/wget/manual/html_node/Wgetrc-Commands.html#Wgetrc-Commands))
+
+    https_proxy = http://host:port/path
+    proxy_user = user
+    proxy_password = password
+    # If need to disable certificate checks
+    check_certificate = off
+
+## Troubleshooting
+
+To experiment and find what settings you need, use `curl` (or `wget`) directly with the node mirror and check the error messages.
+
+For these examples there is a proxy running on localhost:8080 which does not require authentication, but the certificates it offers
+are not trusted.
+
+First try fails because of the certificates and `curl` helpfully explains:
+
+    $ curl --proxy localhost:8080 https://nodejs.org/dist/
+    curl: (60) SSL certificate problem: self signed certificate in certificate chain
+    ...
+    If you'd like to turn off curl's verification of the certificate, use
+    the -k (or --insecure) option.
+    HTTPS-proxy has similar options --proxy-cacert and --proxy-insecure.
+
+Once you get the command to work with settings appropriate for your setup, like:
+
+    $ curl --insecure --proxy localhost:8080 https://nodejs.org/dist/
+    <html>
+    <head><title>Index of /dist/</title></head>
+    ...
+
+then you can try moving the proxy out of the command:
+
+    $ https_proxy=localhost:8080 curl --insecure https://nodejs.org/dist/
+    <html>
+    <head><title>Index of /dist/</title></head>
+    ...
+
+and then `n` should work the same way:
+
+    $ https_proxy=localhost:8080 n --insecure --lts
+    8.11.3
+
+To make it permanent either add settings to the `curl` (or `wget`) startup file, or add the
+environment variable to your shell initialization file . e.g.
+
+    export https_proxy=localhost:8080
+
+For curl, two options of note for debugging are:
+
+    -v, --verbose
+    Makes curl verbose during the operation. Useful for debugging and seeing what's going on "under the hood". ...
+
+    -q, --disable
+    If used as the first parameter on the command line, the curlrc config file will not be read and used. ...

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "n",
-  "version": "5.0.3-0",
+  "version": "6.0.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "n",
-  "version": "6.0.0-0",
+  "version": "6.0.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n",
   "description": "Interactively Manage All Your Node Versions",
-  "version": "6.0.0-0",
+  "version": "6.0.0-1",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "homepage": "https://github.com/tj/n",
   "bugs": "https://github.com/tj/n/issues",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "contributors": [
     {
       "name": "Travis Webb",
-      "email": "me@traviswebb.com",
-      "url": "tjw.io"
+      "email": "me@traviswebb.com"
     },
     {
       "name": "Nimit Kalra",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n",
   "description": "Interactively Manage All Your Node Versions",
-  "version": "5.0.3-0",
+  "version": "6.0.0-0",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "homepage": "https://github.com/tj/n",
   "bugs": "https://github.com/tj/n/issues",

--- a/test/bin/proxy-build
+++ b/test/bin/proxy-build
@@ -24,7 +24,6 @@ echo "Recording downloads..."
 source tests/shared-functions.bash
 unset_n_env
 setup_tmp_prefix
-install_dummy_node
 
 # Hack curl to avoid certificate issues with proxy
 readonly CURL_HOME="$(dirname "${BIN_DIRECTORY}")/config"
@@ -36,10 +35,10 @@ export http_proxy
 https_proxy="$(hostname):8080"
 export https_proxy
 
+# linux. Use wget first so cache uncompressed index.tab and works with both wget and curl.
+docker-compose run ubuntu-wget /mnt/tests/install-reference-versions.bash
 # native
 tests/install-reference-versions.bash
-# linux
-docker-compose run ubuntu-curl /mnt/tests/install-reference-versions.bash
 
 rm -rf "${TMP_PREFIX_DIR}"
 echo "Stopping proxy"

--- a/test/config/.wgetrc
+++ b/test/config/.wgetrc
@@ -1,0 +1,2 @@
+# Allow use of mitm proxy
+check_certificate = off

--- a/test/docker-base.yml
+++ b/test/docker-base.yml
@@ -12,8 +12,9 @@ services:
       - ./tests:/mnt/tests
       # the n script
       - ../bin/n:/usr/local/bin/n
-      # override curl settings to allow insecure connection in case using proxy
+      # override settings to allow insecure connection in case using mitm proxy
       - ./config/.curlrc:/root/.curlrc
+      - ./config/.wgetrc:/root/.wgetrc
     environment:
       # pass through proxy settings to allow caching proxy
       - http_proxy

--- a/test/tests.md
+++ b/test/tests.md
@@ -1,6 +1,6 @@
-# n-test
+# Tests
 
-Prototype and develop a set of automated tests for `n`.
+Automated tests for `n`.
 
 ## Setup
 

--- a/test/tests/install-contents.bats
+++ b/test/tests/install-contents.bats
@@ -21,7 +21,6 @@ function setup() {
   [ ! -d "${N_PREFIX}/lib" ]
   [ ! -d "${N_PREFIX}/shared" ]
 
-  install_dummy_node
   n ${TARGET_VERSION}
 
   # Cached version

--- a/test/tests/install-options.bats
+++ b/test/tests/install-options.bats
@@ -6,7 +6,6 @@ load shared-functions
 function setup() {
   unset_n_env
   setup_tmp_prefix
-  install_dummy_node
 }
 
 

--- a/test/tests/install-reference-versions.bash
+++ b/test/tests/install-reference-versions.bash
@@ -11,3 +11,5 @@ curl --location --fail https://nodejs.org/dist/index.tab &> /dev/null
 n --download 4
 n --download lts
 n --download latest
+n --download nightly/latest
+NVH_NODE_MIRROR=https://npm.taobao.org/mirrors/node n --download 6.11

--- a/test/tests/install-reference-versions.bash
+++ b/test/tests/install-reference-versions.bash
@@ -12,4 +12,4 @@ n --download 4
 n --download lts
 n --download latest
 n --download nightly/latest
-NVH_NODE_MIRROR=https://npm.taobao.org/mirrors/node n --download 6.11
+N_NODE_MIRROR=https://npm.taobao.org/mirrors/node n --download 6.11

--- a/test/tests/install-versions.bats
+++ b/test/tests/install-versions.bats
@@ -6,7 +6,6 @@ load shared-functions
 function setup() {
   unset_n_env
   setup_tmp_prefix
-  install_dummy_node
 }
 
 
@@ -15,41 +14,10 @@ function teardown() {
 }
 
 
-# Explicit version
+# Testing version permutations in lsr tests
+
 @test "n 4.9.1" {
   n 4.9.1
-  run node --version
-  [ "${output}" = "v4.9.1" ]
-}
-
-
-# Explicit version, optional leading v
-@test "n v4.9.1" {
-  n v4.9.1
-  run node --version
-  [ "${output}" = "v4.9.1" ]
-}
-
-
-# Partial version
-@test "n 4" {
-  n 4
-  run node --version
-  [ "${output}" = "v4.9.1" ]
-}
-
-
-# Partial version, optional leading v
-@test "n v4" {
-  n v4
-  run node --version
-  [ "${output}" = "v4.9.1" ]
-}
-
-
-# Partial version
-@test "n 4.9" {
-  n 4.9
   run node --version
   [ "${output}" = "v4.9.1" ]
 }
@@ -58,19 +26,12 @@ function teardown() {
 @test "n lts" {
   n lts
   run node --version
-  [ "${output}" = "$(display_remote_version lts)" ]
-}
-
-
-@test "n stable" {
-  n stable
-  run node --version
-  [ "${output}" = "$(display_remote_version lts)" ]
+  [ "${output}" = "v$(display_remote_version lts)" ]
 }
 
 
 @test "n latest" {
   n latest
   run node --version
-  [ "${output}" = "$(display_remote_version latest)" ]
+  [ "${output}" = "v$(display_remote_version latest)" ]
 }

--- a/test/tests/lookup.bats
+++ b/test/tests/lookup.bats
@@ -18,6 +18,16 @@ function setup() {
 }
 
 
+@test "n --stable" {
+  run n --stable
+  [ "${status}" -eq 0 ]
+  local expected_version
+  expected_version="$(display_remote_version lts)"
+  expected_version="${expected_version#v}"
+  [ "${output}" = "${expected_version}" ]
+}
+
+
 @test "n --latest" {
   run n --latest
   [ "${status}" -eq 0 ]

--- a/test/tests/ls.bats
+++ b/test/tests/ls.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+load shared-functions
+
+function setup() {
+  unset_n_env
+  setup_tmp_prefix
+}
+
+function teardown() {
+  rm -rf "${TMP_PREFIX_DIR}"
+}
+
+
+@test "n ls # just plain node" {
+  # KISS and just make folders rather than do actual installs
+  mkdir -p "${N_PREFIX}/n/versions/node/4.9.1"
+  mkdir -p "${N_PREFIX}/n/versions/node/10.15.0"
+
+  run n ls
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "node/4.9.1" ]
+  [ "${lines[1]}" = "node/10.15.0" ]
+  [ "${lines[2]}" = "" ]
+}
+
+
+@test "n list # mixed node and nightly" {
+  local NIGHTLY_VERSION="12.0.0-nightly201812104aabd7ed64"
+  # KISS and just make folders rather than do actual installs
+  mkdir -p "${N_PREFIX}/n/versions/nightly/${NIGHTLY_VERSION}"
+  mkdir -p "${N_PREFIX}/n/versions/node/10.15.0"
+
+  run n list
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "nightly/${NIGHTLY_VERSION}" ]
+  [ "${lines[1]}" = "node/10.15.0" ]
+  [ "${lines[2]}" = "" ]
+}
+

--- a/test/tests/lsr.bats
+++ b/test/tests/lsr.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+
+load shared-functions
+
+
+function setup() {
+  unset_n_env
+}
+
+
+# labels
+
+@test "n lsr lts" {
+  run n lsr lts
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "$(display_remote_version lts)" ]
+}
+
+@test "n lsr stable" {
+  run n lsr lts
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "$(display_remote_version lts)" ]
+}
+
+@test "n ls-remote latest" {
+  run n ls-remote latest
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "$(display_remote_version latest)" ]
+}
+
+@test "n list-remote current" {
+  run n list-remote current
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "$(display_remote_version latest)" ]
+}
+
+
+# codenames
+
+@test "n=1 n lsr argon" {
+  N_MAX_REMOTE_MATCHES=1 run n lsr argon
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "4.9.1" ]
+}
+
+@test "n=1 n lsr Argon # case" {
+  N_MAX_REMOTE_MATCHES=1 run n lsr Argon
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "4.9.1" ]
+}
+
+
+# numeric versions
+
+@test "n=1 n lsr 4" {
+  N_MAX_REMOTE_MATCHES=1 run n lsr 4
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "4.9.1" ]
+}
+
+@test "n=1 n lsr v4" {
+  N_MAX_REMOTE_MATCHES=1 run n lsr v4
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "4.9.1" ]
+}
+
+@test "n=1 n lsr 4.9" {
+  N_MAX_REMOTE_MATCHES=1 run n lsr 4.9
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "4.9.1" ]
+}
+
+@test "n=1 n lsr 4.9.1" {
+  N_MAX_REMOTE_MATCHES=1 run n lsr 4.9.1
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "4.9.1" ]
+}
+
+@test "n=1 n lsr v4.9.1" {
+  N_MAX_REMOTE_MATCHES=1 run n lsr v4.9.1
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "4.9.1" ]
+}
+
+@test "n lsr 6.2 # multiple matches with header" {
+  run n lsr 6.2
+  [ "${status}" -eq "0" ]
+  [ "${lines[0]}" = "Listing remote... Displaying 20 matches (use --all to see all)." ]
+  [ "${lines[1]}" = "6.2.2" ]
+  [ "${lines[2]}" = "6.2.1" ]
+  [ "${lines[3]}" = "6.2.0" ]
+  [ "${lines[4]}" = "" ]
+}
+
+@test "n=1 n lsr --all 6.2 # --all, multiple matches with no header" {
+  N_MAX_REMOTE_MATCHES=1 run n --all lsr 6.2
+  [ "${status}" -eq "0" ]
+  [ "${lines[0]}" = "6.2.2" ]
+  [ "${lines[1]}" = "6.2.1" ]
+  [ "${lines[2]}" = "6.2.0" ]
+  [ "${lines[3]}" = "" ]
+}
+
+# Checking does not match 8.11
+@test "n=1 n lsr v8.1 # numeric match" {
+  N_MAX_REMOTE_MATCHES=1 run n lsr v8.1
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "8.1.4" ]
+}
+
+
+# Nightly
+
+@test "n=1 n lsr nightly" {
+  N_MAX_REMOTE_MATCHES=1 run n lsr nightly
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "$(display_remote_version nightly)" ]
+}
+
+@test "n=1 n lsr nightly/" {
+  N_MAX_REMOTE_MATCHES=1 run n lsr nightly/
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "$(display_remote_version nightly)" ]
+}
+
+@test "n=1 n lsr nightly/latest" {
+  N_MAX_REMOTE_MATCHES=1 run n lsr nightly/latest
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "$(display_remote_version nightly)" ]
+}
+
+@test "n=1 n lsr nightly/v10.8.1-nightly201808 # partial match" {
+  N_MAX_REMOTE_MATCHES=1 run n lsr nightly/v10.8.1-nightly201808
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "10.8.1-nightly2018081382830a809b" ]
+}
+
+# Numeric match should not find v7.10.1-nightly2017050369a8053e8a
+@test "n=1 n lsr nightly/7.1 # numeric match" {
+  N_MAX_REMOTE_MATCHES=1 run n lsr nightly/7.1
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "7.1.1-nightly201611093daf11635d" ]
+}
+
+# Numeric match should not find v7.10.1-nightly2017050369a8053e8a
+@test "n=1 n lsr nightly/v7.1 # numeric match" {
+  N_MAX_REMOTE_MATCHES=1 run n lsr nightly/v7.1
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "7.1.1-nightly201611093daf11635d" ]
+}
+
+@test "n lsr nightly/v6.10.3-nightly2017040479546c0b5a # exact" {
+  N_MAX_REMOTE_MATCHES=1 run n lsr nightly/v6.10.3-nightly2017040479546c0b5a
+  [ "${status}" -eq "0" ]
+  [ "${output}" = "6.10.3-nightly2017040479546c0b5a" ]
+}

--- a/test/tests/run-which.bats
+++ b/test/tests/run-which.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+
+load shared-functions
+
+function setup() {
+  unset_n_env
+  # fixed directory so can reuse the two installs
+  export N_PREFIX="${TMPDIR}/n/test/run-which"
+  # beforeAll
+  # See https://github.com/bats-core/bats-core/issues/39
+  if [[ "${BATS_TEST_NUMBER}" -eq 1 ]] ; then
+    n --download 4.9.1
+    n --download lts
+  fi
+}
+
+function teardown() {
+  # afterAll
+  if [[ "${#BATS_TEST_NAMES[@]}" -eq "${BATS_TEST_NUMBER}" ]] ; then
+    rm -rf "${N_PREFIX}"
+  fi
+}
+
+
+@test "setupAll for run/which/exec # (2 installs)" {
+  # Dummy test so setupAll displayed while running first setup
+  [ -d "${N_PREFIX}/n/versions/node/4.9.1" ]
+}
+
+
+# n which
+
+@test "n which 4" {
+  run n which 4
+  [ "$status" -eq 0 ]
+  [ "$output" = "${N_PREFIX}/n/versions/node/4.9.1/bin/node" ]
+}
+
+
+@test "n which v4.9.1" {
+  run n which v4.9.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "${N_PREFIX}/n/versions/node/4.9.1/bin/node" ]
+}
+
+
+@test "n bin v4.9.1" {
+  run n bin v4.9.1
+  [ "$status" -eq 0 ]
+  [ "$output" = "${N_PREFIX}/n/versions/node/4.9.1/bin/node" ]
+}
+
+
+@test "n which argon" {
+  run n which argon
+  [ "$status" -eq 0 ]
+  [ "$output" = "${N_PREFIX}/n/versions/node/4.9.1/bin/node" ]
+}
+
+
+@test "n which lts" {
+  run n which lts
+  local LTS_VERSION="$(display_remote_version lts)"
+  [ "$status" -eq 0 ]
+  [ "$output" = "${N_PREFIX}/n/versions/node/${LTS_VERSION}/bin/node" ]
+}
+
+
+# n run
+
+@test "n run 4" {
+  run n run 4 --version
+  [ "$status" -eq 0 ]
+  [ "$output" = "v4.9.1" ]
+}
+
+
+@test "n run lts" {
+  run n run lts --version
+  local LTS_VERSION="$(display_remote_version lts)"
+  [ "$status" -eq 0 ]
+  [ "$output" = "v${LTS_VERSION}" ]
+}
+
+
+@test "n use 4" {
+  run n use 4 --version
+  [ "$status" -eq 0 ]
+  [ "$output" = "v4.9.1" ]
+}
+
+
+@test "n as 4" {
+  run n as 4 --version
+  [ "$status" -eq 0 ]
+  [ "$output" = "v4.9.1" ]
+}
+
+
+
+
+# n exec
+
+@test "n exec v4.9.1 node" {
+  run n exec v4.9.1 node --version
+  [ "$status" -eq 0 ]
+  [ "$output" = "v4.9.1" ]
+}
+
+
+@test "n exec 4 npm" {
+  run n exec 4 npm --version
+  [ "$status" -eq 0 ]
+  [ "$output" = "2.15.11" ]
+}
+
+
+@test "n exec lts" {
+  run n exec lts node --version
+  local LTS_VERSION="$(display_remote_version lts)"
+  [ "$status" -eq 0 ]
+  [ "$output" = "v${LTS_VERSION}" ]
+}

--- a/test/tests/uninstall.bats
+++ b/test/tests/uninstall.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+load shared-functions
+
+function setup() {
+  unset_n_env
+  setup_tmp_prefix
+}
+
+function teardown() {
+  rm -rf "${TMP_PREFIX_DIR}"
+}
+
+
+@test "n uninstall (of lts)" {
+  n lts
+  [ -f "${N_PREFIX}/bin/node" ]
+  [ -f "${N_PREFIX}/bin/npm" ]
+  [ -f "${N_PREFIX}/lib/node_modules/npm/package.json" ]
+
+  # Check we get all the files if we uninstall and rm cache.
+  echo y | n uninstall
+  n rm lts
+  run find "${N_PREFIX}" -not -type d
+  [ "${status}" -eq "0" ]
+  [ "$output" = "" ]
+}
+
+
+@test "n uninstall (of nightly/latest)" {
+  n nightly/latest
+  [ -f "${N_PREFIX}/bin/node" ]
+  [ -f "${N_PREFIX}/bin/npm" ]
+  [ -f "${N_PREFIX}/lib/node_modules/npm/package.json" ]
+
+  # Check we get all the files if we uninstall and rm cache.
+  echo y | n uninstall
+  n rm nightly/latest
+  run find "${N_PREFIX}" -not -type d
+  [ "${status}" -eq "0" ]
+  [ "$output" = "" ]
+}


### PR DESCRIPTION
Adding a Pull Request so some visibility on work in progress.

Pulling in much of the implementation from nvh, while (mostly) retaining the n commands and options.

- use index.tab instead of screen scraping for determining available versions
- support for full version, partial version, code name, and download builds (like nightly)
- consistent lookup of versions across all commands
- improved display of download errors
- et al