### PR TITLE
Press "d" to remove version in menu

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -384,18 +384,13 @@ display_versions_paths() {
 #
 
 display_versions_with_selected() {
-  set_active_node
   selected="$1"
   echo
   for version in $(display_versions_paths); do
-    installed=""
-    if test "$version" = "$g_active_node"; then
-      installed=" [active]"
-    fi
     if test "$version" = "$selected"; then
-      printf "  ${SGR_CYAN}ο${SGR_RESET} %s${SGR_RED}%s${SGR_RESET}\n" "$version" "$installed"
+      printf "  ${SGR_CYAN}ο${SGR_RESET} %s\n" "$version"
     else
-      printf "    ${SGR_FAINT}%s${SGR_RESET}${SGR_RED}%s${SGR_RESET}\n" "$version" "$installed"
+      printf "    ${SGR_FAINT}%s${SGR_RESET}\n" "$version"
     fi
   done
   echo
@@ -455,8 +450,18 @@ menu_select_cache_versions() {
         ;;
       "d")
         clear
-        [[ -n "${selected}" && "${selected}" != "${g_active_node}" ]] && remove_versions "${selected}"
-        display_versions_with_selected "${g_active_node}"
+        after_delete_selection="$(find_selection_after_delete "${selected}")"
+        [[ -n "${selected}" ]] && remove_versions "${selected}"
+        
+        if [ "${after_delete_selection}" == "${selected}" ]; then
+          # If selection stays the same, it means that there is no version installed left.
+          clear
+          leave_fullscreen
+          echo "All versions have been deleted."
+          exit
+        fi
+
+        display_versions_with_selected "${after_delete_selection}"
         ;;
       "k")
         clear
@@ -481,6 +486,16 @@ menu_select_cache_versions() {
         ;;
     esac
   done
+}
+
+find_selection_after_delete() {
+  selected="$1"
+  result=""
+  next="$(next_version_installed "${selected}")"
+  prev="$(prev_version_installed "${selected}")"
+  [[ "${next}" == ${selected}  ]] && result="${prev}" || result="${next}"
+
+  echo "${result}"
 }
 
 #

--- a/bin/n
+++ b/bin/n
@@ -384,17 +384,22 @@ display_versions_paths() {
 #
 
 display_versions_with_selected() {
+  set_active_node
   selected="$1"
   echo
   for version in $(display_versions_paths); do
+    installed=""
+    if test "$version" = "$g_active_node"; then
+      installed=" [active]"
+    fi
     if test "$version" = "$selected"; then
-      printf "  ${SGR_CYAN}ο${SGR_RESET} %s\n" "$version"
+      printf "  ${SGR_CYAN}ο${SGR_RESET} %s${SGR_RED}%s${SGR_RESET}\n" "$version" "$installed"
     else
-      printf "    ${SGR_FAINT}%s${SGR_RESET}\n" "$version"
+      printf "    ${SGR_FAINT}%s${SGR_RESET}${SGR_RED}%s${SGR_RESET}\n" "$version" "$installed"
     fi
   done
   echo
-  printf "Use up/down arrow keys to select a version, return key to install, q to quit"
+  printf "Use up/down arrow keys to select a version, return key to install, d to remove (only inactive versions), q to quit"
 }
 
 #
@@ -447,6 +452,11 @@ menu_select_cache_versions() {
               ;;
           esac
         fi
+        ;;
+      "d")
+        clear
+        [[ -n "${selected}" && "${selected}" != "${g_active_node}" ]] && remove_versions "${selected}"
+        display_versions_with_selected "${g_active_node}"
         ;;
       "k")
         clear

--- a/bin/n
+++ b/bin/n
@@ -399,7 +399,7 @@ display_versions_with_selected() {
     fi
   done
   echo
-  printf "Use up/down arrow keys to select a version, return key to install, d to remove (only inactive versions), q to quit"
+  printf "Use up/down arrow keys to select a version, return key to install, d to delete (only inactive versions), q to quit"
 }
 
 #

--- a/bin/n
+++ b/bin/n
@@ -488,6 +488,10 @@ menu_select_cache_versions() {
   done
 }
 
+#
+# Return either, and in this order, the next, the previous or the current version
+#
+
 find_selection_after_delete() {
   selected="$1"
   result=""

--- a/bin/n
+++ b/bin/n
@@ -394,7 +394,7 @@ display_versions_with_selected() {
     fi
   done
   echo
-  printf "Use up/down arrow keys to select a version, return key to install, d to delete (only inactive versions), q to quit"
+  printf "Use up/down arrow keys to select a version, return key to install, d to delete, q to quit"
 }
 
 #


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request.
-->

## Problem

<!--
What problem are you solving? Include issue numbers if it has been reported. 
Show the broken output if appropriate.
-->

It is quite hard to remove a bunch of previously installed versions without using prune. If I want to keep multiple versions, I cannot do that easily.

## Solution

<!--
How did you solve the problem? 
Show the fixed output if appropriate.
-->

You can now press `d` to remove versions in the menu. You cannot remove the currently active node.

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->

You can now press `d` to remove versions in the menu. You cannot remove the currently active node.
