### PR TITLE
Update tar command to use --no-same-owner

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -608,7 +608,7 @@ install() {
   cd "${dir}" || abort "Failed to cd to ${dir}"
 
   log fetch "$url"
-  do_get "${url}" | tar "$tarflag" --strip-components=1
+  do_get "${url}" | tar "$tarflag" --strip-components=1 --no-same-owner
   [ "$GET_SHOWS_PROGRESS" = "true" ] && erase_line
   rm -f "$dir/n.lock"
 


### PR DESCRIPTION
# Pull Request

## Problem

Downloaded `node` [files](https://nodejs.org/dist/) can have unexpected owners and groups, _e.g._:
```
$ ls -l v10.5.0/
total 164
drwxrwxr-x 2 500 500  4096 Jun 20  2018 bin
-rw-rw-r-- 1 500 500 55929 Jun 20  2018 CHANGELOG.md
drwxrwxr-x 3 500 500  4096 Jun 20  2018 include
drwxrwxr-x 3 500 500  4096 Jun 20  2018 lib
-rw-rw-r-- 1 500 500 63252 Jun 20  2018 LICENSE
-rw-rw-r-- 1 500 500 28518 Jun 20  2018 README.md
drwxrwxr-x 5 500 500  4096 Jun 20  2018 share
```
```
$ ls -l v12.13.0/
total 172
drwxr-xr-x 2 1001 1001  4096 Oct 21 07:41 bin
-rw-r--r-- 1 1001 1001 52722 Oct 21 07:41 CHANGELOG.md
drwxr-xr-x 3 1001 1001  4096 Oct 21 07:41 include
drwxr-xr-x 3 1001 1001  4096 Oct 21 07:41 lib
-rw-r--r-- 1 1001 1001 77127 Oct 21 07:41 LICENSE
-rw-r--r-- 1 1001 1001 26233 Oct 21 07:41 README.md
drwxr-xr-x 5 1001 1001  4096 Oct 21 07:41 share
```
This may unintentionally cause a user to have elevated access to the downloaded files.

## Solution
In the case where an ordinary user executes `n`, the ordinary user owns the downloaded files because the `tar` option `--no-same-owner` is the [default behavior](https://www.gnu.org/software/tar/manual/html_node/Option-Summary.html#SEC42).

However, when `n` is executed using `sudo`, we may get the behavior show above because `--same-owner` is the default behavior.

`--no-same-owner` should be set in **all** cases. This will result in no change for the ordinary user. When run using `sudo`, this will set the owner and group to `root:root` which is both predictable and probably what the user intends.
