### PR TITLE
Use proper path to store application data

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -45,7 +45,7 @@ VERSION="6.0.1"
 N_PREFIX="${N_PREFIX-/usr/local}"
 N_PREFIX=${N_PREFIX%/}
 readonly N_PREFIX
-readonly CACHE_DIR=$N_PREFIX/sharen/versions
+readonly CACHE_DIR=$N_PREFIX/share/versions
 
 N_NODE_MIRROR=${N_NODE_MIRROR:-${NODE_MIRROR:-https://nodejs.org/dist}}
 N_NODE_MIRROR=${N_NODE_MIRROR%/}

--- a/bin/n
+++ b/bin/n
@@ -45,7 +45,7 @@ VERSION="6.0.1"
 N_PREFIX="${N_PREFIX-/usr/local}"
 N_PREFIX=${N_PREFIX%/}
 readonly N_PREFIX
-readonly CACHE_DIR=$N_PREFIX/n/versions
+readonly CACHE_DIR=$N_PREFIX/sharen/versions
 
 N_NODE_MIRROR=${N_NODE_MIRROR:-${NODE_MIRROR:-https://nodejs.org/dist}}
 N_NODE_MIRROR=${N_NODE_MIRROR%/}


### PR DESCRIPTION
# Pull Request

## Problem

By default n is installing data in `$N_PREFIX/n`, with default value this means `/usr/local/n` rather than a more appropriate `/usr/local/share/n`, cf. hier(7)

## Solution

Change `$CACHE_DIR` default.
