### PR TITLE
Fix firewall problems on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- markdownlint-disable MD024 -->
 
+## [Unreleased] (date goes here)
+
+### Fix
+
+- remove old version of node before copy to avoid firewall issues on macOS ([#394])
+
 ## [6.3.0] (2020-02-24)
 
 ### Added
@@ -211,6 +217,7 @@ Only minor functional changes, but technically could break scripts relying on sp
 [#381]: https://github.com/tj/n/issues/381
 [#383]: https://github.com/tj/n/issues/383
 [#391]: https://github.com/tj/n/issues/391
+[#394]: https://github.com/tj/n/issues/394
 [#400]: https://github.com/tj/n/issues/400
 [#416]: https://github.com/tj/n/issues/416
 [#423]: https://github.com/tj/n/issues/423

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 <!-- markdownlint-disable MD024 -->
 
-## [Unreleased] (date goes here)
+## [6.3.1] (2020-02-25)
 
-### Fix
+### Fixed
 
 - remove old version of node before copy to avoid firewall issues on macOS ([#394])
 
@@ -261,6 +261,7 @@ Only minor functional changes, but technically could break scripts relying on sp
 <!-- reference links for releases -->
 
 [Unreleased]: https://github.com/tj/n/compare/master...develop
+[6.3.1]: https://github.com/tj/n/compare/v6.3.0...v6.3.1
 [6.3.0]: https://github.com/tj/n/compare/v6.2.0...v6.3.0
 [6.2.0]: https://github.com/tj/n/compare/v6.1.3...v6.2.0
 [6.1.3]: https://github.com/tj/n/compare/v6.0.2...v6.1.3

--- a/bin/n
+++ b/bin/n
@@ -40,7 +40,7 @@ function echo_red() {
 # Setup and state
 #
 
-VERSION="6.3.1-0"
+VERSION="6.3.1"
 
 N_PREFIX="${N_PREFIX-/usr/local}"
 N_PREFIX=${N_PREFIX%/}

--- a/bin/n
+++ b/bin/n
@@ -573,6 +573,8 @@ activate() {
       rm -rf "$N_PREFIX/lib/node_modules/npm"
     fi
   fi
+  # Remove old node to avoid potential problems with firewall getting confused on Darwin by overwrite.
+  rm -f "$N_PREFIX/bin/node"
   # Copy (lib before bin to avoid error messages on Darwin when cp over dangling link)
   for subdir in lib bin include share; do
     if [[ -n "${N_PRESERVE_NPM}" ]]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "n",
-  "version": "6.3.1-0",
+  "version": "6.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n",
   "description": "Interactively Manage All Your Node Versions",
-  "version": "6.3.1-0",
+  "version": "6.3.1",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "homepage": "https://github.com/tj/n",
   "bugs": "https://github.com/tj/n/issues",


### PR DESCRIPTION
# Pull Request

See #394

## Problem

Changing node versions using `n` causes firewall warnings when a server node application is launched on macOS. Doing an overwrite copy seems to confuse the firewall which does not correctly determine the firewall status of the new binary. Allowing the application to make connections when prompted by the firewall is not remembered. 

Rebooting does fix things. Until the next install.

## Solution

Remove the old version of node before performing the copy during the install.
