### PR TITLE
fix arch match rule for armv8l

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -853,7 +853,7 @@ function display_tarball_platform() {
   case "${uname_m}" in
     x86_64) arch=x64 ;;
     i386 | i686) arch="x86" ;;
-    aarch64) arch=arm64 ;;
+    aarch64 | armv8l) arch=arm64 ;;
     *)
       # e.g. armv6l, armv7l, arm64
       arch="${uname_m}"


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request.
-->

## Problem

<!--
What problem are you solving? Include issue numbers if it has been reported. 
Show the broken output if appropriate.
-->

I have tried to run `n` on my armv8l arch device, but could not get an appropriate result.

```
➜  ~ n lts
  Error: no version found for 'lts'
```

```
➜  ~ n lsr
Listing remote... Displaying 20 matches (use --all to see all).
➜  ~
```

After doing some research I saw some information about [the relations among armv7l, armv8l, and arm64 from StackOverflow](https://stackoverflow.com/questions/41091934/are-armv8-and-arm64-the-same):

> "arm64" represents the AArch64 state of the ARMv8-A architecture; there is no "armv8" target.

So, here is the problem in the script

https://github.com/tj/n/blob/a0cfc8079126c84125bbd53ad4f62e2406bb8e98/bin/n#L853-L861

## Solution

<!--
How did you solve the problem? 
Show the fixed output if appropriate.
-->

Just declare `armv8l` use `arm64` arch

```
aarch64 | armv8l) arch=arm64 ;;
```

And then it works
```
➜  n git:(master) ✗ ./bin/n lts

  installing : node-v12.16.1
       mkdir : /root/n/n/versions/node/12.16.1
       fetch : https://nodejs.org/dist/v12.16.1/node-v12.16.1-linux-arm64.tar.xz
####################################################################      95.7%
```

```
➜  n git:(master) ✗ ./bin/n lsr
Listing remote... Displaying 20 matches (use --all to see all).
13.10.1
13.10.0
13.9.0
13.8.0
13.7.0
13.6.0
13.5.0
13.4.0
13.3.0
13.2.0
13.1.0
13.0.1
13.0.0
12.16.1
12.16.0
12.15.0
12.14.1
12.14.0
12.13.1
12.13.0
```


## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
