### PR TITLE
Add auto label to read version from .node-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased] (date goes here)
 
+## [6.5.0] (2020-04-11)
+
+### Added
+
+- specify `auto` to read the target version from a ` .node-version` file
+
 ## [6.4.0] (2020-03-10)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ There are labels for two especially useful versions:
 - `lts`: newest Long Term Support official release
 - `latest`, `current`: newest official release
   
-Specify `auto` to read the target version from a `.node-version` file.
+There is a label to read the target version from a file, on the first line:
+
+- `auto`: read version from `.node-version` file
 
 There is support for release streams:
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ There are labels for two especially useful versions:
 
 - `lts`: newest Long Term Support official release
 - `latest`, `current`: newest official release
+  
+Specify `auto` to read the target version from a `.node-version` file.
 
 There is support for release streams:
 

--- a/bin/n
+++ b/bin/n
@@ -40,7 +40,7 @@ function echo_red() {
 # Setup and state
 #
 
-VERSION="6.4.1-0"
+VERSION="6.5.0"
 
 N_PREFIX="${N_PREFIX-/usr/local}"
 N_PREFIX=${N_PREFIX%/}
@@ -334,6 +334,7 @@ Versions:
     4.9.1, 8, v6.1    Numeric versions
     lts               Newest Long Term Support official release
     latest, current   Newest official release
+    auto              Read version from .node-version
     boron, carbon     Codenames for release streams
     and nightly, chakracore-release/latest, rc/10 et al
 
@@ -891,11 +892,29 @@ function tarball_url() {
 }
 
 #
+# Synopsis: display_auto_version
+#
+
+function display_auto_version() {
+  local filename=".node-version"
+  [[ -e "${filename}" ]] || abort "auto version file not found (${filename})"
+  # read returns a non-zero status but does still work if there is no line ending
+  <"${filename}" read -r version
+  # trim possible trailing \d from a Windows created file
+  version="${version%%[[:space:]]}"
+  echo "${version}"
+}
+
+#
 # Synopsis: display_latest_resolved_version version
 #
 
 function display_latest_resolved_version() {
-  local version=${1#node/}
+  local version=${1}
+  if [[ "${version}" = "auto" ]]; then
+    version="$(display_auto_version)" || return 2
+  fi
+  version=${version#node/}
   if is_exact_numeric_version "${version}"; then
     # Just numbers, already resolved, no need to lookup first.
     version="${version#v}"
@@ -1295,6 +1314,7 @@ else
       lsr|ls-remote|list-remote) shift; display_remote_versions "$1"; exit ;;
       uninstall) uninstall_installed; exit ;;
       i|install) shift; install "$1"; exit ;;
+      N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION) shift; display_latest_resolved_version "$1"; exit ;;
       *) install "$1"; exit ;;
     esac
     shift

--- a/bin/n
+++ b/bin/n
@@ -914,14 +914,14 @@ function display_latest_resolved_version() {
   if [[ "${version}" = "auto" ]]; then
     version="$(display_auto_version)" || return 2
   fi
-  version=${version#node/}
-  if is_exact_numeric_version "${version}"; then
+  simple_version=${version#node/} # Only place supporting node/ [sic]
+  if is_exact_numeric_version "${simple_version}"; then
     # Just numbers, already resolved, no need to lookup first.
-    version="${version#v}"
-    echo "${version}"
+    simple_version="${simple_version#v}"
+    echo "${simple_version}"
   else
-    # Complicated recognising exact version, KISS and awlays lookup for now.
-    N_MAX_REMOTE_MATCHES=1 display_remote_versions "$1"
+    # Complicated recognising exact version, KISS and lookup.
+    N_MAX_REMOTE_MATCHES=1 display_remote_versions "$version"
   fi
 }
 

--- a/test/tests/run-which.bats
+++ b/test/tests/run-which.bats
@@ -5,7 +5,8 @@ load shared-functions
 function setup() {
   unset_n_env
   # fixed directory so can reuse the two installs
-  export N_PREFIX="${TMPDIR}/n/test/run-which"
+  tmpdir="${TMPDIR:-/tmp}"
+  export N_PREFIX="${tmpdir}/n/test/run-which"
   # beforeAll
   # See https://github.com/bats-core/bats-core/issues/39
   if [[ "${BATS_TEST_NUMBER}" -eq 1 ]] ; then

--- a/test/tests/version-resolve.bats
+++ b/test/tests/version-resolve.bats
@@ -19,32 +19,32 @@ function setup() {
 
 @test "auto, no eol" {
   cd "${MY_DIR}"
-  printf "4.9.1" > .node-version
+  printf "101.0.1" > .node-version
   run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
-  [ "$output" = "4.9.1" ]
+  [ "$output" = "101.0.1" ]
 }
 
 @test "auto, unix eol" {
   cd "${MY_DIR}"
-  printf "4.9.1\n" > .node-version
+  printf "101.0.2\n" > .node-version
   run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
-  [ "$output" = "4.9.1" ]
+  [ "$output" = "101.0.2" ]
 }
 
 @test "auto, Windows eol" {
   cd "${MY_DIR}"
-  printf "4.9.1\r\n" > .node-version
+  printf "101.0.3\r\n" > .node-version
   run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
-  [ "$output" = "4.9.1" ]
+  [ "$output" = "101.0.3" ]
 }
 
 @test "auto, leading v" {
   cd "${MY_DIR}"
-  printf "v4.9.1\n" > .node-version
+  printf "v101.0.4\n" > .node-version
   run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
-  [ "$output" = "4.9.1" ]
+  [ "$output" = "101.0.4" ]
 }

--- a/test/tests/version-resolve.bats
+++ b/test/tests/version-resolve.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+# Note: full semver is resolved without lookup, so can use arbitrary versions for testing like 999.999.999
+
 load shared-functions
 
 
@@ -47,4 +49,21 @@ function setup() {
   run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
   [ "$output" = "101.0.4" ]
+}
+
+@test "auto, first line only" {
+  cd "${MY_DIR}"
+  printf "101.0.5\nmore text\n" > .node-version
+  run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "$output" = "101.0.5" ]
+}
+
+@test "auto, lookup" {
+  # Check normal resolving, which is allowed but not required for MVP .node-version
+  cd "${MY_DIR}"
+  printf "4.9\n" > .node-version
+  run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "$output" = "4.9.1" ]
 }

--- a/test/tests/version-resolve.bats
+++ b/test/tests/version-resolve.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load shared-functions
+
+
+function setup() {
+  unset_n_env
+  tmpdir="${TMPDIR:-/tmp}"
+  export MY_DIR="${tmpdir}/n/test/run-version-resolve"
+  mkdir -p "${MY_DIR}"
+}
+
+@test "auto, missing file" {
+  cd "${MY_DIR}"
+  rm -f .node-version
+  run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -ne 0 ]
+}
+
+@test "auto, no eol" {
+  cd "${MY_DIR}"
+  printf "4.9.1" > .node-version
+  run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "$output" = "4.9.1" ]
+}
+
+@test "auto, unix eol" {
+  cd "${MY_DIR}"
+  printf "4.9.1\n" > .node-version
+  run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "$output" = "4.9.1" ]
+}
+
+@test "auto, Windows eol" {
+  cd "${MY_DIR}"
+  printf "4.9.1\r\n" > .node-version
+  run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "$output" = "4.9.1" ]
+}
+
+@test "auto, leading v" {
+  cd "${MY_DIR}"
+  printf "v4.9.1\n" > .node-version
+  run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "$output" = "4.9.1" ]
+}


### PR DESCRIPTION
# Pull Request

## Problem

People would like to be able to specify the target version in a file, and have it read by their preferred node version manager. The commonly used generic filename is `.node-version`.

Reference: https://github.com/nodejs/version-management/issues/13

## Solution

Read version number from `.node-version` and parse as if it had been given on command line. Be lenient with line endings, as I proposed in https://github.com/nodejs/version-management/issues/13

Use the label `auto`, as used by `nvs` for this purpose.