### PR TITLE
Add node support aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Execute `n` on its own to view your downloaded versions, and install the selecte
 
     Use up/down arrow keys to select a version, return key to install, d to delete, q to quit
 
-(You can also use `j` and `k` to navigate up or down without using arrows.)
+(You can also use <kbd>j</kbd> and <kbd>k</kbd> to navigate up or down without using arrows.)
 
 If the active node version does not change after install, try opening a new shell in case seeing a stale version.
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ There is support for the named release streams:
 
 - `argon`, `boron`, `carbon`: codenames for LTS release streams
 
-The node support aliases may be used, although simply resolve to the latest matching version:
+These node support aliases may be used, although for now simply resolve to the latest matching version:
 
 - `active`, `lts_active`, `lts_latest`, `lts`, `current`
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ There is support for the named release streams:
 
 These node support aliases may be used, although for now simply resolve to the latest matching version:
 
-- `active`, `lts_active`, `lts_latest`, `lts`, `current`
+- `active`, `lts_active`, `lts_latest`, `lts`, `current`, `supported`
 
 The last form is for specifying [other releases](https://nodejs.org/download) available using the name of the remote download folder optionally followed by the complete or incomplete version.
 

--- a/README.md
+++ b/README.md
@@ -109,9 +109,13 @@ There is a label to read the target version from a file, on the first line:
 
 - `auto`: read version from `.n-node-version` file
 
-There is support for release streams:
+There is support for the named release streams:
 
 - `argon`, `boron`, `carbon`: codenames for LTS release streams
+
+The node support aliases may be used, although simply resolve to the latest matching version:
+
+- `active`, `lts_active`, `lts_latest`, `lts`, `current`
 
 The last form is for specifying [other releases](https://nodejs.org/download) available using the name of the remote download folder optionally followed by the complete or incomplete version.
 

--- a/bin/n
+++ b/bin/n
@@ -251,7 +251,7 @@ function is_exact_numeric_version() {
 #
 
 function is_node_support_version() {
-  [[ "$1" =~ ^(active|lts_active|lts_latest|lts|current)$ ]]
+  [[ "$1" =~ ^(active|lts_active|lts_latest|lts|current|supported)$ ]]
 }
 
 #
@@ -266,6 +266,7 @@ function display_latest_node_support_alias() {
     "lts_latest") printf "lts" ;;
     "lts") printf "lts" ;;
     "current") printf "current" ;;
+    "supported") printf "current" ;;
     *) printf "unexpected-version"
   esac
 }

--- a/bin/n
+++ b/bin/n
@@ -1345,7 +1345,7 @@ else
       lsr|ls-remote|list-remote) shift; display_remote_versions "$1"; exit ;;
       uninstall) uninstall_installed; exit ;;
       i|install) shift; install "$1"; exit ;;
-      N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION) shift; display_latest_resolved_version "$1"; exit ;;
+      N_TEST_DISPLAY_LATEST_RESOLVED_VERSION) shift; display_latest_resolved_version "$1"; exit ;;
       *) install "$1"; exit ;;
     esac
     shift

--- a/bin/n
+++ b/bin/n
@@ -251,7 +251,7 @@ function is_exact_numeric_version() {
 #
 
 function is_node_support_version() {
-  [[ "$1" =~ ^(all|active|lts_active|lts_latest|lts|current)$ ]]
+  [[ "$1" =~ ^(active|lts_active|lts_latest|lts|current)$ ]]
 }
 
 #
@@ -261,7 +261,6 @@ function is_node_support_version() {
 
 function display_latest_node_support_alias() {
   case "$1" in
-    "all") printf "current" ;;
     "active") printf "current" ;;
     "lts_active") printf "lts" ;;
     "lts_latest") printf "lts" ;;
@@ -362,6 +361,8 @@ Versions:
     latest, current   Newest official release
     auto              Read version from .n-node-version
     boron, carbon     Codenames for release streams
+    lts_latest        node support aliases
+
     and nightly, chakracore-release/latest, rc/10 et al
 
 EOF

--- a/bin/n
+++ b/bin/n
@@ -246,6 +246,32 @@ function is_exact_numeric_version() {
 }
 
 #
+# Synopsis: is_node_support_version version
+# Reference: https://github.com/nodejs/package-maintenance/issues/236#issue-474783582
+#
+
+function is_node_support_version() {
+  [[ "$1" =~ ^(all|active|lts_active|lts_latest|lts|current)$ ]]
+}
+
+#
+# Synopsis: display_latest_node_support_alias version
+# Map aliases onto existing n aliases, current and lts
+#
+
+function display_latest_node_support_alias() {
+  case "$1" in
+    "all") printf "current" ;;
+    "active") printf "current" ;;
+    "lts_active") printf "lts" ;;
+    "lts_latest") printf "lts" ;;
+    "lts") printf "lts" ;;
+    "current") printf "current" ;;
+    *) printf "unexpected-version"
+  esac
+}
+
+#
 # Functions used when showing versions installed
 #
 
@@ -962,6 +988,10 @@ function display_remote_versions() {
   update_mirror_settings_for_version "${version}"
   local match='.'
   local match_count="${N_MAX_REMOTE_MATCHES}"
+  if is_node_support_version "${version}"; then
+    version="$(display_latest_node_support_alias "${version}")"
+    match_count=1
+  fi
   if [[ -z "${version}" ]]; then
     match='.'
   elif [[ "${version}" = "lts" || "${version}" = "stable" ]]; then

--- a/test/tests/version-resolve.bats
+++ b/test/tests/version-resolve.bats
@@ -15,14 +15,14 @@ function setup() {
 @test "auto, missing file" {
   cd "${MY_DIR}"
   rm -f .n-node-version
-  run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -ne 0 ]
 }
 
 @test "auto, no eol" {
   cd "${MY_DIR}"
   printf "101.0.1" > .n-node-version
-  run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
   [ "$output" = "101.0.1" ]
 }
@@ -30,7 +30,7 @@ function setup() {
 @test "auto, unix eol" {
   cd "${MY_DIR}"
   printf "101.0.2\n" > .n-node-version
-  run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
   [ "$output" = "101.0.2" ]
 }
@@ -38,7 +38,7 @@ function setup() {
 @test "auto, Windows eol" {
   cd "${MY_DIR}"
   printf "101.0.3\r\n" > .n-node-version
-  run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
   [ "$output" = "101.0.3" ]
 }
@@ -46,7 +46,7 @@ function setup() {
 @test "auto, leading v" {
   cd "${MY_DIR}"
   printf "v101.0.4\n" > .n-node-version
-  run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
   [ "$output" = "101.0.4" ]
 }
@@ -54,7 +54,7 @@ function setup() {
 @test "auto, first line only" {
   cd "${MY_DIR}"
   printf "101.0.5\nmore text\n" > .n-node-version
-  run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
   [ "$output" = "101.0.5" ]
 }
@@ -63,7 +63,7 @@ function setup() {
   # Check normal resolving, which is allowed but not required for MVP
   cd "${MY_DIR}"
   printf "4.9\n" > .n-node-version
-  run n N_MOCK_DISPLAY_LATEST_RESOLVED_VERSION auto
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
   [ "$output" = "4.9.1" ]
 }

--- a/test/tests/version-resolve.bats
+++ b/test/tests/version-resolve.bats
@@ -67,3 +67,47 @@ function setup() {
   [ "$status" -eq 0 ]
   [ "$output" = "4.9.1" ]
 }
+
+# node support aliases
+
+@test "display_latest_resolved_version active" {
+  local TARGET_VERSION="$(display_remote_version latest)"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION active
+  [ "$status" -eq 0 ]
+  [ "$output" = "${TARGET_VERSION}" ]
+}
+
+@test "display_latest_resolved_version lts_active" {
+  local TARGET_VERSION="$(display_remote_version lts)"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION lts_active
+  [ "$status" -eq 0 ]
+  [ "$output" = "${TARGET_VERSION}" ]
+}
+
+@test "display_latest_resolved_version lts_latest" {
+  local TARGET_VERSION="$(display_remote_version lts)"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION lts_latest
+  [ "$status" -eq 0 ]
+  [ "$output" = "${TARGET_VERSION}" ]
+}
+
+@test "display_latest_resolved_version lts" {
+  local TARGET_VERSION="$(display_remote_version lts)"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION lts
+  [ "$status" -eq 0 ]
+  [ "$output" = "${TARGET_VERSION}" ]
+}
+
+@test "display_latest_resolved_version current" {
+  local TARGET_VERSION="$(display_remote_version latest)"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION current
+  [ "$status" -eq 0 ]
+  [ "$output" = "${TARGET_VERSION}" ]
+}
+
+@test "display_latest_resolved_version supported" {
+  local TARGET_VERSION="$(display_remote_version latest)"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION supported
+  [ "$status" -eq 0 ]
+  [ "$output" = "${TARGET_VERSION}" ]
+}


### PR DESCRIPTION
# Pull Request

## Problem

Node are defining some aliases to describe the versions of node a package supports (and/or is tested against), and would like to standardise their use in their own documentation, and encourage support in other tooling.

See #617 for links and further information.

## Solution

The EOL information is not available in `index.tab` yet, so simply map the support aliases onto either `lts` or `current` from previous `n` usage.

In the future, enhancing `ls-remote` to list all the matching versions would be a nice feature and add some value to their support in `n` beyond simply allowing their use.

## ChangeLog

tba