### PR TITLE
Enable xz by default on macOS 11+

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -824,9 +824,14 @@ function can_use_xz() {
   if [[ "${uname_s}" = "Linux" ]] && command -v xz &> /dev/null ; then
     # tar on linux is likely to support xz if it is available as a command
     return 0
-  elif [[ "${uname_s}" = "Darwin" && "$(sw_vers -productVersion | cut -d '.' -f 2)" -gt "8" ]]; then
-    # tar on recent Darwin has xz support built-in
-    return 0
+  elif [[ "${uname_s}" = "Darwin" ]]; then
+    local macos_version="$(sw_vers -productVersion)"
+    local macos_major_version="$(echo ${macos_version} | cut -d '.' -f 1)"
+    local macos_minor_version="$(echo ${macos_version} | cut -d '.' -f 2)"
+    if [[ "${macos_major_version}" -gt 10 || "${macos_minor_version}" -gt 8 ]]; then
+      # tar on recent Darwin has xz support built-in
+      return 0
+    fi
   fi
   return 2 # not supported
 }


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request.
-->

## Problem

Resolves #623.

macOS 11 has been announced. At the moment, the system check in can_use_xz() only cares about the OS minor version being greater than 8, so as it stands, `n` would think the upcoming macOS 11.0.0 doesn't support xz decompression via tar. Downloads would fall back to fetching gzip tarballs.

_(I think it's reasonable to assume Apple will keep xz support in tar, as opposed to abruptly dropping it.)_

## Solution

In this PR, the check in can_use_xz() now allows any major macOS version 11+, in addition to allowing any macOS with minor version 8 or greater.


<details><summary>An aside about `sw_vers` and why this loose logic is good enough (Click to expand.)</summary>

We check the macOS version with the `sw_vers` utility. The only Mac operating system versions with the `sw_vers` utility are versions 10+. On old enough OS X/Mac OS, `sw_vers` command doesn't exist; As such, I'd expect to see this on `stderr`:

```console
$ macos_version=$(sw_vers -productVersion)
sw_vers: command not found
```

As that output is on `stderr` and nothing is in `stdout`, `$macos_version` holds an empty string and fails the version check. In this scenario, I would expect `n` to fall back to using `gzip`.

_(I simulated that scenario by being on Ubuntu (no `sw_vers` command here!) and setting `macos_version="$(sw_vers -productVersion)"` and running the version checks against this `$macos_version`, which indeed was an empty string and failed the version checks.)_

My mental "truth table" of this check, considering all that, is as follows:

| | OS X/macOS major version 10 | macOS major version 11+ | Some older Mac OS version <= 9| 
| ------------- | ------------- | ------------- | ------------- |
| **Minor version 8 or less** | ❌ No xz (use gzip) | ✔️ Use xz | ❌ No xz (use gzip) | 
| **Minor version 9+** | ✔️ Use xz   | ✔️ Use xz   | ❌ No xz (use gzip) | 

This all looks correct to me, and I'm satisfied the logic theoretically works as intended. Typos or bugs notwithstanding.

</details>

## ChangeLog

Enable xz support by default for macOS 11+