### PR TITLE
Extend auto support to include .node-version, .nvmrc, and engines field of package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- markdownlint-disable MD024 -->
 
-## [Unreleased] (date goes here)
+## [6.7.0] (2020-07-25)
+
+### Added
+
+- `auto` support for:
+    - `.node-version`
+    - `.nvmrc`
+    - `engines` field of `package.json`
 
 ## [6.6.0] (2020-07-04)
 

--- a/README.md
+++ b/README.md
@@ -105,9 +105,12 @@ There are labels for two especially useful versions:
 - `lts`: newest Long Term Support official release
 - `latest`, `current`: newest official release
   
-There is a label to read the target version from a file, on the first line:
+There is an `auto` label to read the target version from a file in the current directory, or any parent directory. `n` looks for in order:
 
-- `auto`: read version from `.n-node-version` file
+- `.n-node-version`: version on single line. Custom to `n`.
+- `.node-version`: version on single line. Used by multiple tools: [node-version-usage](https://github.com/shadowspawn/node-version-usage)
+- `.nvmrc`: version on single line. Used by `nvm`.
+- `package.json`: use `engines` field to determine compatible `node`. Requires an installed version of `node`, and uses `npx semver` to resolve complex ranges.
 
 There is support for the named release streams:
 

--- a/bin/n
+++ b/bin/n
@@ -10,7 +10,7 @@ log() {
   printf "  ${SGR_CYAN}%10s${SGR_RESET} : ${SGR_FAINT}%s${SGR_RESET}\n" "$1" "$2"
 }
 trace_log() {
-  >&2 log $1 $2
+  >&2 log "$1" "$2"
 }
 
 #
@@ -43,7 +43,7 @@ function echo_red() {
 # Setup and state
 #
 
-VERSION="6.6.1-0"
+VERSION="6.7.0"
 
 N_PREFIX="${N_PREFIX-/usr/local}"
 N_PREFIX=${N_PREFIX%/}

--- a/bin/n
+++ b/bin/n
@@ -7,7 +7,10 @@
 #
 
 log() {
-  printf "  ${SGR_CYAN}%10s${SGR_RESET} : ${SGR_FAINT}%s${SGR_RESET}${SGR_RESET}\n" "$1" "$2"
+  printf "  ${SGR_CYAN}%10s${SGR_RESET} : ${SGR_FAINT}%s${SGR_RESET}\n" "$1" "$2"
+}
+trace_log() {
+  >&2 log $1 $2
 }
 
 #
@@ -360,7 +363,7 @@ Versions:
     4.9.1, 8, v6.1    Numeric versions
     lts               Newest Long Term Support official release
     latest, current   Newest official release
-    auto              Read version from .n-node-version
+    auto              Read version from file: .n-node-version, .node-version, .nvmrc, or package.json
     boron, carbon     Codenames for release streams
     lts_latest        node support aliases
 
@@ -925,17 +928,102 @@ function tarball_url() {
 }
 
 #
+# Synopsis: display_file_node_version filename
+#
+
+function display_file_node_version() {
+  local filepath="$1"
+  trace_log "found" "${filepath}"
+  # read returns a non-zero status but does still work if there is no line ending
+  local version
+  <"${filepath}" read -r version
+  # trim possible trailing \d from a Windows created file
+  version="${version%%[[:space:]]}"
+  trace_log "read" "${version}"
+  echo "${version}"
+}
+
+#
+# Synopsis: display_package_engine_version
+#
+
+function display_package_engine_version() {
+  local filepath="$1"
+  trace_log "found" "${filepath}"
+  command -v node &> /dev/null || abort "an active version of node is required to read 'engines' from package.json"
+  local range
+  range="$(node -e "package = require('${filepath}'); if (package && package.engines && package.engines.node) console.log(package.engines.node)")"
+  trace_log "read" "${range}"
+  if [[ -z "${range}" || "*" == "${range}" ]]; then
+    echo "current"
+    return
+  fi
+
+  local version
+  if [[ "${range}" =~ ^([>~^=]|\>\=)?v?([0-9]+(\.[0-9]+){0,2})(.[xX*])?$ ]]; then
+    local operator="${BASH_REMATCH[1]}"
+    version="${BASH_REMATCH[2]}"
+    case "${operator}" in
+      '' | =) ;;
+      \> | \>=) version="current" ;;
+      \~) [[ "${version}" =~ ^([0-9]+\.[0-9]+)\.[0-9]+$ ]] && version="${BASH_REMATCH[1]}" ;;
+      ^) [[ "${version}" =~ ^([0-9]+) ]] && version="${BASH_REMATCH[1]}" ;;
+    esac
+  else
+    command -v npx &> /dev/null || abort "an active version of npx is required to use complex 'engine' ranges from package.json"
+    trace_log "resolving" "${range}"
+    local version_per_line="$(n lsr --all)"
+    local versions_one_line=$(echo "${version_per_line}" | tr '\n' ' ')
+    # Using semver@7 so works with older versions of node.
+    # shellcheck disable=SC2086
+    version=$(npx --quiet semver@7 -r "${range}" ${versions_one_line} | tail -n 1)
+  fi
+  echo "${version}"
+}
+
+#
+# Synopsis: display_nvmrc_version
+#
+
+function display_nvmrc_version() {
+  local filepath="$1"
+  trace_log "found" "${filepath}"
+  local version
+  <"${filepath}" read -r version
+  trace_log "read" "${version}"
+  # Translate from nvm aliases
+  case "${version}" in
+    lts/\*) version="lts" ;;
+    lts/*) version="${version:4}" ;;
+    node) version="current" ;;
+    *) ;;
+  esac
+  echo "${version}"
+}
+
+#
 # Synopsis: display_auto_version
 #
 
 function display_auto_version() {
-  local filename=".n-node-version"
-  [[ -e "${filename}" ]] || abort "auto version file not found (${filename})"
-  # read returns a non-zero status but does still work if there is no line ending
-  <"${filename}" read -r version
-  # trim possible trailing \d from a Windows created file
-  version="${version%%[[:space:]]}"
-  echo "${version}"
+  local parent
+  parent="${PWD}"
+  while [[ -n "${parent}" ]]; do
+    if [[ -e "${parent}/.n-node-version" ]]; then
+      display_file_node_version "${parent}/.n-node-version"
+    elif [[ -e "${parent}/.node-version" ]]; then
+      display_file_node_version "${parent}/.node-version"
+    elif [[ -e "${parent}/.nvmrc" ]]; then
+      display_nvmrc_version "${parent}/.nvmrc"
+    elif [[ -e "${parent}/package.json" ]]; then
+      display_package_engine_version "${parent}/package.json"
+    else
+      parent=${parent%/*}
+      continue
+    fi
+    break
+  done
+  [[ -n "${parent}" ]] || abort "no file found for auto version"
 }
 
 #

--- a/test/tests/version-auto-priority.bats
+++ b/test/tests/version-auto-priority.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+load shared-functions
+
+
+# auto
+
+function setup() {
+  unset_n_env
+  tmpdir="${TMPDIR:-/tmp}"
+  export MY_DIR="${tmpdir}/n/test/version-resolve-auto-priority"
+  mkdir -p "${MY_DIR}"
+  rm -f "${MY_DIR}/package.json"
+  rm -f "${MY_DIR}/.n-node-version"
+  rm -f "${MY_DIR}/.node-version"
+  rm -f "${MY_DIR}/.nvmrc"
+
+  PAYLOAD_LINE=2
+
+  # Need a version of node available for reading package.json
+  export N_PREFIX="${MY_DIR}"
+  export PATH="${MY_DIR}/bin:${PATH}"
+  if [[ "${BATS_TEST_NUMBER}" -eq 1 ]] ; then
+    # beforeAll
+    n install lts
+  fi
+}
+
+function teardown() {
+  # afterAll
+  if [[ "${#BATS_TEST_NAMES[@]}" -eq "${BATS_TEST_NUMBER}" ]] ; then
+    rm -rf "${MY_DIR}"
+  fi
+}
+
+@test ".n-node-version first" {
+  cd "${MY_DIR}"
+  echo "401.0.1" > .n-node-version
+  echo "401.0.2" > .node-version
+  echo "401.0.3" > .nvmrc
+  echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
+
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "401.0.1" ]
+}
+
+@test ".node-version second" {
+  cd "${MY_DIR}"
+  echo "401.0.2" > .node-version
+  echo "401.0.3" > .nvmrc
+  echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
+
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "401.0.2" ]
+}
+
+@test ".nvmrc third" {
+  cd "${MY_DIR}"
+  echo "401.0.3" > .nvmrc
+  echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
+
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "401.0.3" ]
+}
+
+@test ".package.json last" {
+  cd "${MY_DIR}"
+  echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
+
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "401.0.4" ]
+}
+

--- a/test/tests/version-resolve-auto-engine.bats
+++ b/test/tests/version-resolve-auto-engine.bats
@@ -1,0 +1,208 @@
+#!/usr/bin/env bats
+
+load shared-functions
+
+
+# auto
+
+function setup() {
+  unset_n_env
+  tmpdir="${TMPDIR:-/tmp}"
+  export MY_DIR="${tmpdir}/n/test/version-resolve-auto-engine"
+  mkdir -p "${MY_DIR}"
+  rm -f "${MY_DIR}/package.json"
+
+  # Need a version of node and npx available for reading package.json
+  export N_PREFIX="${MY_DIR}"
+  export PATH="${MY_DIR}/bin:${PATH}"
+  # beforeAll
+  if [[ "${BATS_TEST_NUMBER}" -eq 1 ]] ; then
+    n install lts
+  fi
+
+  # Output looks likes:
+  ##        found : package.json
+  ##         read : 101.0.1
+  ## v101.0.1
+  # so version payload is...
+  PAYLOAD_SIMPLE_LINE=2
+
+  # Output looks likes:
+  ##        found : package.json
+  ##       read : 4.8.2 - 4.8.4
+  ##  resolving : 4.8.2 - 4.8.4
+  ## v4.8.4
+  # so version payload is...
+  PAYLOAD_COMPLEX_LINE=3
+}
+
+function teardown() {
+  # afterAll
+  if [[ "${#BATS_TEST_NAMES[@]}" -eq "${BATS_TEST_NUMBER}" ]] ; then
+    rm -rf "${MY_DIR}"
+  fi
+}
+
+function write_engine() {
+  echo '{ "engines" : { "node" : "'"$1"'" } }' > package.json
+}
+
+@test "setupAll for auto-engine # (1 install)" {
+  # Dummy test so setupAll displayed while running first setup
+}
+
+@test "auto engine, 104.0.1" {
+  cd "${MY_DIR}"
+  write_engine "103.0.1"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "103.0.1" ]
+}
+
+@test "auto engine, v104.0.2" {
+  cd "${MY_DIR}"
+  write_engine "v104.0.2"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "104.0.2" ]
+}
+
+@test "auto engine, =104.0.3" {
+  cd "${MY_DIR}"
+  write_engine "=103.0.3"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "103.0.3" ]
+}
+
+@test "auto engine, =v104.0.4" {
+  cd "${MY_DIR}"
+  write_engine "=v104.0.4"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "104.0.4" ]
+}
+
+@test "auto engine, >1" {
+  local TARGET_VERSION="$(display_remote_version latest)"
+  cd "${MY_DIR}"
+  write_engine ">1"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "${TARGET_VERSION}" ]
+}
+
+@test "auto engine, >=2" {
+  local TARGET_VERSION="$(display_remote_version latest)"
+  cd "${MY_DIR}"
+  write_engine ">=2"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "${TARGET_VERSION}" ]
+}
+
+@test "auto engine, 8" {
+  cd "${MY_DIR}"
+  write_engine "8"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.17.0" ]
+}
+
+@test "auto engine, 8.x" {
+  cd "${MY_DIR}"
+  write_engine "8.x"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.17.0" ]
+}
+
+@test "auto engine, 8.X" {
+  cd "${MY_DIR}"
+  write_engine "8.X"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.17.0" ]
+}
+
+@test "auto engine, 8.*" {
+  cd "${MY_DIR}"
+  write_engine "8.*"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.17.0" ]
+}
+
+@test "auto engine, ~8.11.0" {
+  cd "${MY_DIR}"
+  write_engine "~8.11.0"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.11.4" ]
+}
+
+@test "auto engine, ~8.11" {
+  cd "${MY_DIR}"
+  write_engine "~8.11"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.11.4" ]
+}
+
+@test "auto engine, ~8" {
+  cd "${MY_DIR}"
+  write_engine "~8"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.17.0" ]
+}
+
+@test "auto engine, ^8.11.0" {
+  cd "${MY_DIR}"
+  write_engine "^8.11.0"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.17.0" ]
+}
+
+@test "auto engine, ^8.x" {
+  cd "${MY_DIR}"
+  write_engine "^8.x"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.17.0" ]
+}
+
+@test "auto engine, subdir" {
+  cd "${MY_DIR}"
+  write_engine "8.11.2"
+  mkdir -p sub-engine
+  cd sub-engine
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.11.2" ]
+}
+
+@test "auto engine (semver), <8.12" {
+  cd "${MY_DIR}"
+  write_engine "<8.12"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_COMPLEX_LINE}]}" = "8.11.4" ]
+}
+
+@test "auto engine (semver), 8.11.1 - 8.11.3" {
+  cd "${MY_DIR}"
+  write_engine "8.11.1 - 8.11.3"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_COMPLEX_LINE}]}" = "8.11.3" ]
+}
+
+@test "auto engine (semver), >8.1 <8.12 || >2.1 <3.4" {
+  cd "${MY_DIR}"
+  write_engine ">8.1 <8.12 || >2.1 <3.4"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_COMPLEX_LINE}]}" = "8.11.4" ]
+}

--- a/test/tests/version-resolve-auto-file.bats
+++ b/test/tests/version-resolve-auto-file.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+
+# Note: full semver is resolved without lookup, so can use arbitrary versions for testing like 999.999.999
+# Not testing all the permutations on both files, as know they are currenly implemented using same code!
+
+load shared-functions
+
+
+# auto
+
+function setup() {
+  unset_n_env
+  tmpdir="${TMPDIR:-/tmp}"
+  export MY_DIR="${tmpdir}/n/test/version-resolve-auto-file"
+  mkdir -p "${MY_DIR}"
+  rm -f "${MY_DIR}/.n-node-version"
+  rm -f "${MY_DIR}/.node-version"
+
+  # Output looks likes:
+  ##        found : .n-node-version
+  ##         read : 101.0.1
+  ## v101.0.1
+  # so payload to check is on line #2.
+  PAYLOAD_LINE=2
+}
+
+function teardown() {
+  # afterAll
+  if [[ "${#BATS_TEST_NAMES[@]}" -eq "${BATS_TEST_NUMBER}" ]] ; then
+    rm -rf "${MY_DIR}"
+  fi
+}
+
+@test "auto, missing file" {
+  cd "${MY_DIR}"
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -ne 0 ]
+}
+
+@test "auto .n-node-version, no eol" {
+  cd "${MY_DIR}"
+  printf "101.0.1" > .n-node-version
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "101.0.1" ]
+}
+
+@test "auto .n-node-version, unix eol" {
+  cd "${MY_DIR}"
+  printf "101.0.2\n" > .n-node-version
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "101.0.2" ]
+}
+
+@test "auto .n-node-version, Windows eol" {
+  cd "${MY_DIR}"
+  printf "101.0.3\r\n" > .n-node-version
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "101.0.3" ]
+}
+
+@test "auto .n-node-version, leading v" {
+  cd "${MY_DIR}"
+  printf "v101.0.4\n" > .n-node-version
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "101.0.4" ]
+}
+
+@test "auto .n-node-version, first line only" {
+  cd "${MY_DIR}"
+  printf "101.0.5\nmore text\n" > .n-node-version
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "101.0.5" ]
+}
+
+@test "auto .n-node-version, from sub directory" {
+  cd "${MY_DIR}"
+  printf "101.0.6\nmore text\n" > .n-node-version
+  mkdir -p sub6
+  cd sub6
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "101.0.6" ]
+}
+
+@test "auto .node-version, partial version lookup" {
+  # Check normal resolving
+  cd "${MY_DIR}"
+  printf "4.9\n" > .node-version
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "4.9.1" ]
+}
+
+@test "auto .node-version, from sub directory" {
+  cd "${MY_DIR}"
+  printf "101.0.7\nmore text\n" > .n-node-version
+  mkdir -p sub7
+  cd sub7
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "101.0.7" ]
+}
+

--- a/test/tests/version-resolve-auto-nvmrc.bats
+++ b/test/tests/version-resolve-auto-nvmrc.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+
+# Note: full semver is resolved without lookup, so can use arbitrary versions for testing like 999.999.999
+
+load shared-functions
+
+
+# auto
+
+function setup() {
+  unset_n_env
+  tmpdir="${TMPDIR:-/tmp}"
+  export MY_DIR="${tmpdir}/n/test/version-resolve-auto-nvmrc"
+  mkdir -p "${MY_DIR}"
+  rm -f "${MY_DIR}/.nvmrc"
+
+  # Output looks likes:
+  ##        found : .nvmrc
+  ##         read : 101.0.1
+  ## v101.0.1
+  # so payload to check is on line #2.
+  PAYLOAD_LINE=2
+}
+
+function teardown() {
+  # afterAll
+  if [[ "${#BATS_TEST_NAMES[@]}" -eq "${BATS_TEST_NUMBER}" ]] ; then
+    rm -rf "${MY_DIR}"
+  fi
+}
+
+@test "auto .nvmrc, numeric" {
+  cd "${MY_DIR}"
+  printf "102.0.1\n" > .nvmrc
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "102.0.1" ]
+}
+
+@test "auto .nvmrc, numeric with leading v" {
+  cd "${MY_DIR}"
+  printf "v102.0.2\n" > .nvmrc
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "102.0.2" ]
+}
+
+@test "auto .nvmrc, node" {
+  local TARGET_VERSION="$(display_remote_version latest)"
+  cd "${MY_DIR}"
+  printf "node\n" > .nvmrc
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "${TARGET_VERSION}" ]
+}
+
+@test "auto .nvmrc, lts/*" {
+  local TARGET_VERSION="$(display_remote_version lts)"
+  cd "${MY_DIR}"
+  printf "lts/*\n" > .nvmrc
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "${TARGET_VERSION}" ]
+}
+
+@test "auto .nvmrc, lts/argon" {
+  local TARGET_VERSION="$(display_remote_version lts)"
+  cd "${MY_DIR}"
+  printf "lts/argon\n" > .nvmrc
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "4.9.1" ]
+}
+
+@test "auto .nvmrc, sub directory" {
+  cd "${MY_DIR}"
+  printf "v102.0.3\n" > .nvmrc
+  mkdir -p sub-npmrc
+  cd sub-npmrc
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "102.0.3" ]
+}

--- a/test/tests/version-resolve.bats
+++ b/test/tests/version-resolve.bats
@@ -7,66 +7,8 @@ load shared-functions
 
 function setup() {
   unset_n_env
-  tmpdir="${TMPDIR:-/tmp}"
-  export MY_DIR="${tmpdir}/n/test/run-version-resolve"
-  mkdir -p "${MY_DIR}"
 }
 
-@test "auto, missing file" {
-  cd "${MY_DIR}"
-  rm -f .n-node-version
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -ne 0 ]
-}
-
-@test "auto, no eol" {
-  cd "${MY_DIR}"
-  printf "101.0.1" > .n-node-version
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "$output" = "101.0.1" ]
-}
-
-@test "auto, unix eol" {
-  cd "${MY_DIR}"
-  printf "101.0.2\n" > .n-node-version
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "$output" = "101.0.2" ]
-}
-
-@test "auto, Windows eol" {
-  cd "${MY_DIR}"
-  printf "101.0.3\r\n" > .n-node-version
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "$output" = "101.0.3" ]
-}
-
-@test "auto, leading v" {
-  cd "${MY_DIR}"
-  printf "v101.0.4\n" > .n-node-version
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "$output" = "101.0.4" ]
-}
-
-@test "auto, first line only" {
-  cd "${MY_DIR}"
-  printf "101.0.5\nmore text\n" > .n-node-version
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "$output" = "101.0.5" ]
-}
-
-@test "auto, lookup" {
-  # Check normal resolving, which is allowed but not required for MVP
-  cd "${MY_DIR}"
-  printf "4.9\n" > .n-node-version
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "$output" = "4.9.1" ]
-}
 
 # node support aliases
 


### PR DESCRIPTION
# Pull Request

## Problem

#625 #618 #616

## Solution

Extend file searching to include parent directories.

Read version from  `.node-version` using previously written code which reads file formats as compatible with other products.

Read `.nvmrc` and translate from some of the `nvm` version conventions.

Read engines from `package.json` using `node`. Use some regex matching to avoid invoking `npx` unless needed for a complex target version. Note: the engines support can not be used for bootstrapping, since it requires `node` and potentially also `npx`.

## ChangeLog

Version and changelog updated [sic].