### PR TITLE
Detect download failure

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -689,6 +689,9 @@ install() {
 
   log fetch "$url"
   do_get "${url}" | tar "$tarflag" --strip-components=1 --no-same-owner
+  if [[ "${PIPESTATUS[0]}" -ne 0 ]]; then
+    abort "failed to download archive for $version"
+  fi
   [ "$GET_SHOWS_PROGRESS" = "true" ] && erase_line
   rm -f "$dir/n.lock"
 

--- a/test/dockerfiles/Dockerfile-ubuntu-curl
+++ b/test/dockerfiles/Dockerfile-ubuntu-curl
@@ -3,7 +3,7 @@ FROM ubuntu:latest
 # curl
 
 RUN apt-get update \
-&& apt-get install -y curl \
+&& apt-get install -y curl rsync \
 && rm -rf /var/lib/apt/lists/*
 
 CMD ["/bin/bash"]

--- a/test/dockerfiles/Dockerfile-ubuntu-wget
+++ b/test/dockerfiles/Dockerfile-ubuntu-wget
@@ -3,7 +3,7 @@ FROM ubuntu:latest
 # wget
 
 RUN apt-get update \
-&& apt-get install -y wget \
+&& apt-get install -y wget rsync \
 && rm -rf /var/lib/apt/lists/*
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
# Pull Request

## Problem

After a problem causing a partial archive download the install carries on and can result in a corrupt install.

See #634

## Solution

Check for command failing, and fail install. Leaving the lock file behind means the next attempt to install tries the download again and does not use the suspect cache folder.

## ChangeLog

- detect and handle a broken download of full archive
