### PR TITLE
Fix auto support to ignore package.json when no engines found

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -949,12 +949,17 @@ function display_file_node_version() {
 
 function display_package_engine_version() {
   local filepath="$1"
-  trace_log "found" "${filepath}"
   command -v node &> /dev/null || abort "an active version of node is required to read 'engines' from package.json"
   local range
   range="$(node -e "package = require('${filepath}'); if (package && package.engines && package.engines.node) console.log(package.engines.node)")"
+  if [[ -z "${range}" ]]; then
+    return
+  fi
+
+  trace_log "found" "${filepath}"
   trace_log "read" "${range}"
-  if [[ -z "${range}" || "*" == "${range}" ]]; then
+
+  if [[ "*" == "${range}" ]]; then
     echo "current"
     return
   fi
@@ -1011,17 +1016,21 @@ function display_auto_version() {
   while [[ -n "${parent}" ]]; do
     if [[ -e "${parent}/.n-node-version" ]]; then
       display_file_node_version "${parent}/.n-node-version"
+      break
     elif [[ -e "${parent}/.node-version" ]]; then
       display_file_node_version "${parent}/.node-version"
+      break
     elif [[ -e "${parent}/.nvmrc" ]]; then
       display_nvmrc_version "${parent}/.nvmrc"
+      break
     elif [[ -e "${parent}/package.json" ]]; then
-      display_package_engine_version "${parent}/package.json"
-    else
-      parent=${parent%/*}
-      continue
+      local package_engine_version=$(display_package_engine_version "${parent}/package.json")
+      if [[ -n "${package_engine_version}" ]]; then
+        echo "${package_engine_version}"
+        break
+      fi
     fi
-    break
+    parent=${parent%/*}
   done
   [[ -n "${parent}" ]] || abort "no file found for auto version"
 }

--- a/test/tests/version-auto-priority.bats
+++ b/test/tests/version-auto-priority.bats
@@ -8,12 +8,13 @@ load shared-functions
 function setup() {
   unset_n_env
   tmpdir="${TMPDIR:-/tmp}"
-  export MY_DIR="${tmpdir}/n/test/version-resolve-auto-priority"
+  export MY_DIR="${tmpdir}/n/test/version-resolve-auto-priority/package"
   mkdir -p "${MY_DIR}"
   rm -f "${MY_DIR}/package.json"
   rm -f "${MY_DIR}/.n-node-version"
   rm -f "${MY_DIR}/.node-version"
   rm -f "${MY_DIR}/.nvmrc"
+  rm -f "${MY_DIR}/../.n-node-version"
 
   PAYLOAD_LINE=2
 
@@ -39,6 +40,7 @@ function teardown() {
   echo "401.0.2" > .node-version
   echo "401.0.3" > .nvmrc
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
+  echo "401.0.5" > ../.n-node-version
 
   run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
@@ -50,6 +52,7 @@ function teardown() {
   echo "401.0.2" > .node-version
   echo "401.0.3" > .nvmrc
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
+  echo "401.0.5" > ../.n-node-version
 
   run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
@@ -60,18 +63,31 @@ function teardown() {
   cd "${MY_DIR}"
   echo "401.0.3" > .nvmrc
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
+  echo "401.0.5" > ../.n-node-version
 
   run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
   [ "${lines[${PAYLOAD_LINE}]}" = "401.0.3" ]
 }
 
-@test ".package.json last" {
+@test "package.json last" {
   cd "${MY_DIR}"
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
+  echo "401.0.5" > ../.n-node-version
 
   run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
   [ "$status" -eq 0 ]
   [ "${lines[${PAYLOAD_LINE}]}" = "401.0.4" ]
+}
+
+@test "parent directory" {
+  cd "${MY_DIR}"
+  # Ignore package.json if it has no engines.node
+  echo '{}' > package.json
+  echo "401.0.5" > ../.n-node-version
+
+  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
+  [ "$status" -eq 0 ]
+  [ "${lines[${PAYLOAD_LINE}]}" = "401.0.5" ]
 }
 


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request.
-->

## Problem

<!--
What problem are you solving? Include issue numbers if it has been reported. 
Show the broken output if appropriate.
-->

`auto` stops at the first `package.json` it sees, even if that `package.json` does not contain `engines.node` (https://github.com/tj/n/issues/636)

## Solution

<!--
How did you solve the problem? 
Show the fixed output if appropriate.
-->

If the `package.json` does not contain `engines.node`, continue looking for other `auto` files

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->

> `auto`: Ignore `package.json` when it does not contain `engines.node`