### PR TITLE
Fix wrong version string match for colorized grep

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -40,6 +40,15 @@ function echo_red() {
 }
 
 #
+# Synopsis: grep [args] [pattern]
+# Grep wrapper to ensure consistent grep options and circumvent aliases
+#
+
+function n_grep() {
+  GREP_OPTIONS='' command grep "$@"
+}
+
+#
 # Setup and state
 #
 
@@ -383,7 +392,7 @@ err_no_installed_print_help() {
 #
 
 function next_version_installed() {
-  display_cache_versions | grep "$1" -A 1 | tail -n 1
+  display_cache_versions | n_grep "$1" -A 1 | tail -n 1
 }
 
 #
@@ -392,7 +401,7 @@ function next_version_installed() {
 #
 
 function prev_version_installed() {
-  display_cache_versions | grep "$1" -B 1 | head -n 1
+  display_cache_versions | n_grep "$1" -B 1 | head -n 1
 }
 
 #
@@ -436,7 +445,7 @@ function set_active_node() {
 display_versions_paths() {
   find "$CACHE_DIR" -maxdepth 2 -type d \
     | sed 's|'"$CACHE_DIR"'/||g' \
-    | grep -E "/[0-9]+\.[0-9]+\.[0-9]+" \
+    | n_grep -E "/[0-9]+\.[0-9]+\.[0-9]+" \
     | sed 's|/|.|' \
     | sort -k 1,1 -k 2,2n -k 3,3n -k 4,4n -t . \
     | sed 's|\.|/|'
@@ -1140,11 +1149,11 @@ function display_remote_versions() {
   # - restrict search to compatible files as not always available, or not at same time
   # - return status of curl command (i.e. PIPESTATUS[0])
   display_remote_index \
-    | grep -E "$(display_compatible_file_field)" \
-    | grep -E "${match}" \
+    | n_grep -E "$(display_compatible_file_field)" \
+    | n_grep -E "${match}" \
     | awk "NR<=${match_count}" \
     | cut -f 1 \
-    | grep -E -o '[^v].*'
+    | n_grep -E -o '[^v].*'
   return "${PIPESTATUS[0]}"
 }
 


### PR DESCRIPTION
* Add a wrapper function for grep to ensure consistency across different
  aliases and options by forcing it to use builtin grep without GREP_OPTIONS

# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request.
-->

## Problem #642 

When running `n <version>` I got this error message:
```
$ n 10

/usr/local/bin/n: line 194: [[: v10: syntax error: operand expected (error token is "v10")

  installing : node-vv10.23.0
curl: (3) [globbing] bad range in column 28

  Error: download preflight failed for 'v10.23.0' (https://nodejs.org/dist/vv10.23.0/node-vv10.23.0-darwin-x64.tar.xz)
```

it seemed like the URL is incorrect: `vv10.23.0` in the above example instead of `v10.23.0`

The problem turned out to be because I had enabled colorized grep a long time ago in `.bash_profile` as it is, in most use cases, helpful for me to highlight matches. 
```
# color grep
export GREP_OPTIONS='--color=always'
```
However, some regex patterns in `n` matched on these ANSI color codes produced by colorized grep:
```
^[[01;31m^[[Kv10.^[[m^[[K23.0   2020-10-27  aix-ppc64,headers,linux-arm64,linux-armv6l,linux-armv7l,linux-ppc64le,linux-s390x,linux-x64,osx-x64-pkg,^[[01;31m^[[Kosx-x64-tar^[[m^[[K,src,sunos-x64,win-x64-7z,win-x64-exe,win-x64-msi,win-x64-zip,win-x86-7z,win-x86-exe,win-x86-msi,win-x86-zip    6.14.8  6.8.275.32  1.34.2  1.2.11  1.1.1g  64  Dubnium -
```
and produced an incorrect version string

## Solution

Create and use a wrapper function for grep that ensures we use the built-in `grep` without any additional `GREP_OPTIONS`.

```
function n_grep() {
  GREP_OPTIONS='' command grep "$@"
}
```

## ChangeLog

Fix bug caused by colorized grep output
