### PR TITLE
WIP: Scan package.json last

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ There is an `auto` label to read the target version from a file in the current d
 - `.n-node-version`: version on single line. Custom to `n`.
 - `.node-version`: version on single line. Used by multiple tools: [node-version-usage](https://github.com/shadowspawn/node-version-usage)
 - `.nvmrc`: version on single line. Used by `nvm`.
-- `package.json`: use `engines` field to determine compatible `node`. Requires an installed version of `node`, and uses `npx semver` to resolve complex ranges.
+- if no version file found, look for `engine` as below.
+
+The `engine` label looks for a `package.json` file and reads the `engines` field to determine compatible `node`. Requires an installed version of `node`, and uses `npx semver` to resolve complex ranges.
 
 There is support for the named release streams:
 

--- a/bin/n
+++ b/bin/n
@@ -222,7 +222,7 @@ function is_lts_codename() {
 
 function is_download_folder() {
   # e.g. nightly
-  [[ "$1" =~ ^(chakracore-nightly|chakracore-rc|chakracore-release|next-nightly|nightly|rc|release|test|v8-canary)$ ]]
+  [[ "$1" =~ ^(next-nightly|nightly|rc|release|test|v8-canary)$ ]]
 }
 
 #
@@ -373,10 +373,11 @@ Versions:
     lts               Newest Long Term Support official release
     latest, current   Newest official release
     auto              Read version from file: .n-node-version, .node-version, .nvmrc, or package.json
+    engine            Read version from package.json
     boron, carbon     Codenames for release streams
     lts_latest        node support aliases
 
-    and nightly, chakracore-release/latest, rc/10 et al
+    and nightly, rc/10 et al
 
 EOF
 }
@@ -1065,6 +1066,7 @@ function display_auto_version() {
 
 function display_latest_resolved_version() {
   local version=${1}
+  # auto and engine make sense for local use and not much for ls-remote, so handled here rather than display_remote_versions
   if [[ "${version}" = "auto" ]]; then
     version="$(display_auto_version)" || return 2
   fi
@@ -1255,7 +1257,7 @@ function show_diagnostics() {
   printf "\nnode\n"
   if command -v node &> /dev/null; then
     command -v node && node --version
-    node -e 'if (process.versions.v8) console.log("JavaScript engine: v8"); if (process.versions.chakracore) console.log("JavaScript engine: chakracore")'
+    node -e 'if (process.versions.v8) console.log("JavaScript engine: v8");'
 
     printf "\nnpm\n"
     command -v npm && npm --version

--- a/bin/n
+++ b/bin/n
@@ -684,7 +684,6 @@ install() {
     fi
   fi
 
-  echo
   log installing "${g_mirror_folder_name}-v$version"
 
   local url="$(tarball_url "$version")"
@@ -709,7 +708,6 @@ install() {
   if "$ACTIVATE" ; then
     activate "${g_mirror_folder_name}/$version"
   fi
-  echo
 }
 
 #
@@ -969,6 +967,7 @@ function display_package_engine_version() {
   range="$(node -e "package = require('${filepath}'); if (package && package.engines && package.engines.node) console.log(package.engines.node)")"
   trace_log "read" "${range}"
   if [[ -z "${range}" || "*" == "${range}" ]]; then
+    trace_log "target" "current"
     echo "current"
     return
   fi
@@ -983,6 +982,7 @@ function display_package_engine_version() {
       \~) [[ "${version}" =~ ^([0-9]+\.[0-9]+)\.[0-9]+$ ]] && version="${BASH_REMATCH[1]}" ;;
       ^) [[ "${version}" =~ ^([0-9]+) ]] && version="${BASH_REMATCH[1]}" ;;
     esac
+    trace_log "target" "${version}"
   else
     command -v npx &> /dev/null || abort "an active version of npx is required to use complex 'engine' ranges from package.json"
     trace_log "resolving" "${range}"
@@ -1016,10 +1016,31 @@ function display_nvmrc_version() {
 }
 
 #
+# Synopsis: display_engine_version [error-message]
+#
+
+function display_engine_version() {
+  local error_message="${1-package.json not found}"
+  local parent
+  parent="${PWD}"
+  while [[ -n "${parent}" ]]; do
+    if [[ -e "${parent}/package.json" ]]; then
+      display_package_engine_version "${parent}/package.json"
+    else
+      parent=${parent%/*}
+      continue
+    fi
+    break
+  done
+  [[ -n "${parent}" ]] || abort "${error_message}"
+}
+
+#
 # Synopsis: display_auto_version
 #
 
 function display_auto_version() {
+  # Search for a version control file first
   local parent
   parent="${PWD}"
   while [[ -n "${parent}" ]]; do
@@ -1029,17 +1050,15 @@ function display_auto_version() {
       display_file_node_version "${parent}/.node-version"
     elif [[ -e "${parent}/.nvmrc" ]]; then
       display_nvmrc_version "${parent}/.nvmrc"
-    elif [[ -e "${parent}/package.json" ]]; then
-      display_package_engine_version "${parent}/package.json"
     else
       parent=${parent%/*}
       continue
     fi
     break
   done
-  [[ -n "${parent}" ]] || abort "no file found for auto version"
+  # Fallback to package.json
+  [[ -n "${parent}" ]] || display_engine_version "no file found for auto version (.n-node-version, .node-version, .nvmrc, or package.json)"
 }
-
 #
 # Synopsis: display_latest_resolved_version version
 #
@@ -1048,6 +1067,9 @@ function display_latest_resolved_version() {
   local version=${1}
   if [[ "${version}" = "auto" ]]; then
     version="$(display_auto_version)" || return 2
+  fi
+  if [[ "${version}" = "engine" ]]; then
+    version="$(display_engine_version)" || return 2
   fi
   simple_version=${version#node/} # Only place supporting node/ [sic]
   if is_exact_numeric_version "${simple_version}"; then

--- a/test/tests/version-auto-priority.bats
+++ b/test/tests/version-auto-priority.bats
@@ -39,7 +39,7 @@ function teardown() {
   echo "401.0.3" > .nvmrc
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "401.0.1" ]
 }
 
@@ -49,7 +49,7 @@ function teardown() {
   echo "401.0.3" > .nvmrc
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "401.0.2" ]
 }
 
@@ -58,7 +58,7 @@ function teardown() {
   echo "401.0.3" > .nvmrc
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "401.0.3" ]
 }
 
@@ -66,7 +66,7 @@ function teardown() {
   cd "${MY_DIR}"
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "401.0.4" ]
 }
 
@@ -77,7 +77,7 @@ function teardown() {
   cd package
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "401.0.2" ]
 
   rm package.json

--- a/test/tests/version-auto-priority.bats
+++ b/test/tests/version-auto-priority.bats
@@ -10,12 +10,11 @@ function setup() {
   tmpdir="${TMPDIR:-/tmp}"
   export MY_DIR="${tmpdir}/n/test/version-resolve-auto-priority"
   mkdir -p "${MY_DIR}"
+  # Bit fragile, but reuse directory and clean up between tests.
   rm -f "${MY_DIR}/package.json"
   rm -f "${MY_DIR}/.n-node-version"
   rm -f "${MY_DIR}/.node-version"
   rm -f "${MY_DIR}/.nvmrc"
-
-  PAYLOAD_LINE=2
 
   # Need a version of node available for reading package.json
   export N_PREFIX="${MY_DIR}"
@@ -40,9 +39,8 @@ function teardown() {
   echo "401.0.3" > .nvmrc
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "401.0.1" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "401.0.1" ]
 }
 
 @test ".node-version second" {
@@ -51,9 +49,8 @@ function teardown() {
   echo "401.0.3" > .nvmrc
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "401.0.2" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "401.0.2" ]
 }
 
 @test ".nvmrc third" {
@@ -61,17 +58,29 @@ function teardown() {
   echo "401.0.3" > .nvmrc
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "401.0.3" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "401.0.3" ]
 }
 
 @test ".package.json last" {
   cd "${MY_DIR}"
   echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
 
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "401.0.4" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "401.0.4" ]
 }
 
+@test ".package.json last, after parent scanning" {
+  cd "${MY_DIR}"
+  echo "401.0.2" > .node-version
+  mkdir package
+  cd package
+  echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
+
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "401.0.2" ]
+
+  rm package.json
+  cd ..
+  rmdir package
+}

--- a/test/tests/version-resolve-auto-engine.bats
+++ b/test/tests/version-resolve-auto-engine.bats
@@ -40,35 +40,35 @@ function write_engine() {
 @test "auto engine, 104.0.1" {
   cd "${MY_DIR}"
   write_engine "103.0.1"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "103.0.1" ]
 }
 
 @test "auto engine, v104.0.2" {
   cd "${MY_DIR}"
   write_engine "v104.0.2"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "104.0.2" ]
 }
 
 @test "auto engine, =104.0.3" {
   cd "${MY_DIR}"
   write_engine "=103.0.3"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "103.0.3" ]
 }
 
 @test "auto engine, =v104.0.4" {
   cd "${MY_DIR}"
   write_engine "=v104.0.4"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "104.0.4" ]
 }
 
 @test "engine, =v104.0.5" {
   cd "${MY_DIR}"
   write_engine "=v104.0.5"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION engine)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION engine)"
   [ "${output}" = "104.0.5" ]
 }
 
@@ -76,7 +76,7 @@ function write_engine() {
   local TARGET_VERSION="$(display_remote_version latest)"
   cd "${MY_DIR}"
   write_engine ">1"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "${TARGET_VERSION}" ]
 }
 
@@ -84,70 +84,70 @@ function write_engine() {
   local TARGET_VERSION="$(display_remote_version latest)"
   cd "${MY_DIR}"
   write_engine ">=2"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "${TARGET_VERSION}" ]
 }
 
 @test "auto engine, 8" {
   cd "${MY_DIR}"
   write_engine "8"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "8.17.0" ]
 }
 
 @test "auto engine, 8.x" {
   cd "${MY_DIR}"
   write_engine "8.x"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "8.17.0" ]
 }
 
 @test "auto engine, 8.X" {
   cd "${MY_DIR}"
   write_engine "8.X"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "8.17.0" ]
 }
 
 @test "auto engine, 8.*" {
   cd "${MY_DIR}"
   write_engine "8.*"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "8.17.0" ]
 }
 
 @test "auto engine, ~8.11.0" {
   cd "${MY_DIR}"
   write_engine "~8.11.0"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "8.11.4" ]
 }
 
 @test "auto engine, ~8.11" {
   cd "${MY_DIR}"
   write_engine "~8.11"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "8.11.4" ]
 }
 
 @test "auto engine, ~8" {
   cd "${MY_DIR}"
   write_engine "~8"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "8.17.0" ]
 }
 
 @test "auto engine, ^8.11.0" {
   cd "${MY_DIR}"
   write_engine "^8.11.0"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "8.17.0" ]
 }
 
 @test "auto engine, ^8.x" {
   cd "${MY_DIR}"
   write_engine "^8.x"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "8.17.0" ]
 }
 
@@ -156,27 +156,27 @@ function write_engine() {
   write_engine "8.11.2"
   mkdir -p sub-engine
   cd sub-engine
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "8.11.2" ]
 }
 
 @test "auto engine (semver), <8.12" {
   cd "${MY_DIR}"
   write_engine "<8.12"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "8.11.4" ]
 }
 
 @test "auto engine (semver), 8.11.1 - 8.11.3" {
   cd "${MY_DIR}"
   write_engine "8.11.1 - 8.11.3"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "8.11.3" ]
 }
 
 @test "auto engine (semver), >8.1 <8.12 || >2.1 <3.4" {
   cd "${MY_DIR}"
   write_engine ">8.1 <8.12 || >2.1 <3.4"
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "8.11.4" ]
 }

--- a/test/tests/version-resolve-auto-engine.bats
+++ b/test/tests/version-resolve-auto-engine.bats
@@ -4,6 +4,7 @@ load shared-functions
 
 
 # auto
+# engine is a label too! These tests mostly use auto as first available only through auto.
 
 function setup() {
   unset_n_env
@@ -19,21 +20,6 @@ function setup() {
   if [[ "${BATS_TEST_NUMBER}" -eq 1 ]] ; then
     n install lts
   fi
-
-  # Output looks likes:
-  ##        found : package.json
-  ##         read : 101.0.1
-  ## v101.0.1
-  # so version payload is...
-  PAYLOAD_SIMPLE_LINE=2
-
-  # Output looks likes:
-  ##        found : package.json
-  ##       read : 4.8.2 - 4.8.4
-  ##  resolving : 4.8.2 - 4.8.4
-  ## v4.8.4
-  # so version payload is...
-  PAYLOAD_COMPLEX_LINE=3
 }
 
 function teardown() {
@@ -54,123 +40,115 @@ function write_engine() {
 @test "auto engine, 104.0.1" {
   cd "${MY_DIR}"
   write_engine "103.0.1"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "103.0.1" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "103.0.1" ]
 }
 
 @test "auto engine, v104.0.2" {
   cd "${MY_DIR}"
   write_engine "v104.0.2"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "104.0.2" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "104.0.2" ]
 }
 
 @test "auto engine, =104.0.3" {
   cd "${MY_DIR}"
   write_engine "=103.0.3"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "103.0.3" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "103.0.3" ]
 }
 
 @test "auto engine, =v104.0.4" {
   cd "${MY_DIR}"
   write_engine "=v104.0.4"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "104.0.4" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "104.0.4" ]
+}
+
+@test "engine, =v104.0.5" {
+  cd "${MY_DIR}"
+  write_engine "=v104.0.5"
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION engine)"
+  [ "${output}" = "104.0.5" ]
 }
 
 @test "auto engine, >1" {
   local TARGET_VERSION="$(display_remote_version latest)"
   cd "${MY_DIR}"
   write_engine ">1"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "${TARGET_VERSION}" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "${TARGET_VERSION}" ]
 }
 
 @test "auto engine, >=2" {
   local TARGET_VERSION="$(display_remote_version latest)"
   cd "${MY_DIR}"
   write_engine ">=2"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "${TARGET_VERSION}" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "${TARGET_VERSION}" ]
 }
 
 @test "auto engine, 8" {
   cd "${MY_DIR}"
   write_engine "8"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.17.0" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "8.17.0" ]
 }
 
 @test "auto engine, 8.x" {
   cd "${MY_DIR}"
   write_engine "8.x"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.17.0" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "8.17.0" ]
 }
 
 @test "auto engine, 8.X" {
   cd "${MY_DIR}"
   write_engine "8.X"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.17.0" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "8.17.0" ]
 }
 
 @test "auto engine, 8.*" {
   cd "${MY_DIR}"
   write_engine "8.*"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.17.0" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "8.17.0" ]
 }
 
 @test "auto engine, ~8.11.0" {
   cd "${MY_DIR}"
   write_engine "~8.11.0"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.11.4" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "8.11.4" ]
 }
 
 @test "auto engine, ~8.11" {
   cd "${MY_DIR}"
   write_engine "~8.11"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.11.4" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "8.11.4" ]
 }
 
 @test "auto engine, ~8" {
   cd "${MY_DIR}"
   write_engine "~8"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.17.0" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "8.17.0" ]
 }
 
 @test "auto engine, ^8.11.0" {
   cd "${MY_DIR}"
   write_engine "^8.11.0"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.17.0" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "8.17.0" ]
 }
 
 @test "auto engine, ^8.x" {
   cd "${MY_DIR}"
   write_engine "^8.x"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.17.0" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "8.17.0" ]
 }
 
 @test "auto engine, subdir" {
@@ -178,31 +156,27 @@ function write_engine() {
   write_engine "8.11.2"
   mkdir -p sub-engine
   cd sub-engine
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_SIMPLE_LINE}]}" = "8.11.2" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "8.11.2" ]
 }
 
 @test "auto engine (semver), <8.12" {
   cd "${MY_DIR}"
   write_engine "<8.12"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_COMPLEX_LINE}]}" = "8.11.4" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "8.11.4" ]
 }
 
 @test "auto engine (semver), 8.11.1 - 8.11.3" {
   cd "${MY_DIR}"
   write_engine "8.11.1 - 8.11.3"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_COMPLEX_LINE}]}" = "8.11.3" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "8.11.3" ]
 }
 
 @test "auto engine (semver), >8.1 <8.12 || >2.1 <3.4" {
   cd "${MY_DIR}"
   write_engine ">8.1 <8.12 || >2.1 <3.4"
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_COMPLEX_LINE}]}" = "8.11.4" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "8.11.4" ]
 }

--- a/test/tests/version-resolve-auto-file.bats
+++ b/test/tests/version-resolve-auto-file.bats
@@ -33,35 +33,35 @@ function teardown() {
 @test "auto .n-node-version, no eol" {
   cd "${MY_DIR}"
   printf "101.0.1" > .n-node-version
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "101.0.1" ]
 }
 
 @test "auto .n-node-version, unix eol" {
   cd "${MY_DIR}"
   printf "101.0.2\n" > .n-node-version
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "101.0.2" ]
 }
 
 @test "auto .n-node-version, Windows eol" {
   cd "${MY_DIR}"
   printf "101.0.3\r\n" > .n-node-version
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "101.0.3" ]
 }
 
 @test "auto .n-node-version, leading v" {
   cd "${MY_DIR}"
   printf "v101.0.4\n" > .n-node-version
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "101.0.4" ]
 }
 
 @test "auto .n-node-version, first line only" {
   cd "${MY_DIR}"
-  printf "101.0.5\nmore text\n" > .n-node-version
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  # printf "101.0.5\nmore text\n" > .n-node-version
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "101.0.5" ]
 }
 
@@ -70,7 +70,7 @@ function teardown() {
   printf "101.0.6\nmore text\n" > .n-node-version
   mkdir -p sub6
   cd sub6
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "101.0.6" ]
 }
 
@@ -78,7 +78,7 @@ function teardown() {
   # Check normal resolving
   cd "${MY_DIR}"
   printf "4.9\n" > .node-version
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "4.9.1" ]
 }
 
@@ -87,7 +87,7 @@ function teardown() {
   printf "101.0.7\nmore text\n" > .n-node-version
   mkdir -p sub7
   cd sub7
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "101.0.7" ]
 }
 

--- a/test/tests/version-resolve-auto-file.bats
+++ b/test/tests/version-resolve-auto-file.bats
@@ -60,7 +60,7 @@ function teardown() {
 
 @test "auto .n-node-version, first line only" {
   cd "${MY_DIR}"
-  # printf "101.0.5\nmore text\n" > .n-node-version
+  printf "101.0.5\nmore text\n" > .n-node-version
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "101.0.5" ]
 }

--- a/test/tests/version-resolve-auto-file.bats
+++ b/test/tests/version-resolve-auto-file.bats
@@ -15,13 +15,6 @@ function setup() {
   mkdir -p "${MY_DIR}"
   rm -f "${MY_DIR}/.n-node-version"
   rm -f "${MY_DIR}/.node-version"
-
-  # Output looks likes:
-  ##        found : .n-node-version
-  ##         read : 101.0.1
-  ## v101.0.1
-  # so payload to check is on line #2.
-  PAYLOAD_LINE=2
 }
 
 function teardown() {
@@ -40,41 +33,36 @@ function teardown() {
 @test "auto .n-node-version, no eol" {
   cd "${MY_DIR}"
   printf "101.0.1" > .n-node-version
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "101.0.1" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "101.0.1" ]
 }
 
 @test "auto .n-node-version, unix eol" {
   cd "${MY_DIR}"
   printf "101.0.2\n" > .n-node-version
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "101.0.2" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "101.0.2" ]
 }
 
 @test "auto .n-node-version, Windows eol" {
   cd "${MY_DIR}"
   printf "101.0.3\r\n" > .n-node-version
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "101.0.3" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "101.0.3" ]
 }
 
 @test "auto .n-node-version, leading v" {
   cd "${MY_DIR}"
   printf "v101.0.4\n" > .n-node-version
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "101.0.4" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "101.0.4" ]
 }
 
 @test "auto .n-node-version, first line only" {
   cd "${MY_DIR}"
   printf "101.0.5\nmore text\n" > .n-node-version
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "101.0.5" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "101.0.5" ]
 }
 
 @test "auto .n-node-version, from sub directory" {
@@ -82,18 +70,16 @@ function teardown() {
   printf "101.0.6\nmore text\n" > .n-node-version
   mkdir -p sub6
   cd sub6
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "101.0.6" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "101.0.6" ]
 }
 
 @test "auto .node-version, partial version lookup" {
   # Check normal resolving
   cd "${MY_DIR}"
   printf "4.9\n" > .node-version
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "4.9.1" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "4.9.1" ]
 }
 
 @test "auto .node-version, from sub directory" {
@@ -101,8 +87,7 @@ function teardown() {
   printf "101.0.7\nmore text\n" > .n-node-version
   mkdir -p sub7
   cd sub7
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "101.0.7" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "101.0.7" ]
 }
 

--- a/test/tests/version-resolve-auto-nvmrc.bats
+++ b/test/tests/version-resolve-auto-nvmrc.bats
@@ -25,14 +25,14 @@ function teardown() {
 @test "auto .nvmrc, numeric" {
   cd "${MY_DIR}"
   printf "102.0.1\n" > .nvmrc
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "102.0.1" ]
 }
 
 @test "auto .nvmrc, numeric with leading v" {
   cd "${MY_DIR}"
   printf "v102.0.2\n" > .nvmrc
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "102.0.2" ]
 }
 
@@ -40,7 +40,7 @@ function teardown() {
   local TARGET_VERSION="$(display_remote_version latest)"
   cd "${MY_DIR}"
   printf "node\n" > .nvmrc
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "${TARGET_VERSION}" ]
 }
 
@@ -48,7 +48,7 @@ function teardown() {
   local TARGET_VERSION="$(display_remote_version lts)"
   cd "${MY_DIR}"
   printf "lts/*\n" > .nvmrc
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "${TARGET_VERSION}" ]
 }
 
@@ -56,7 +56,7 @@ function teardown() {
   local TARGET_VERSION="$(display_remote_version lts)"
   cd "${MY_DIR}"
   printf "lts/argon\n" > .nvmrc
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "4.9.1" ]
 }
 
@@ -65,6 +65,6 @@ function teardown() {
   printf "v102.0.3\n" > .nvmrc
   mkdir -p sub-npmrc
   cd sub-npmrc
-  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   [ "${output}" = "102.0.3" ]
 }

--- a/test/tests/version-resolve-auto-nvmrc.bats
+++ b/test/tests/version-resolve-auto-nvmrc.bats
@@ -13,13 +13,6 @@ function setup() {
   export MY_DIR="${tmpdir}/n/test/version-resolve-auto-nvmrc"
   mkdir -p "${MY_DIR}"
   rm -f "${MY_DIR}/.nvmrc"
-
-  # Output looks likes:
-  ##        found : .nvmrc
-  ##         read : 101.0.1
-  ## v101.0.1
-  # so payload to check is on line #2.
-  PAYLOAD_LINE=2
 }
 
 function teardown() {
@@ -32,44 +25,39 @@ function teardown() {
 @test "auto .nvmrc, numeric" {
   cd "${MY_DIR}"
   printf "102.0.1\n" > .nvmrc
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "102.0.1" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "102.0.1" ]
 }
 
 @test "auto .nvmrc, numeric with leading v" {
   cd "${MY_DIR}"
   printf "v102.0.2\n" > .nvmrc
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "102.0.2" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "102.0.2" ]
 }
 
 @test "auto .nvmrc, node" {
   local TARGET_VERSION="$(display_remote_version latest)"
   cd "${MY_DIR}"
   printf "node\n" > .nvmrc
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "${TARGET_VERSION}" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "${TARGET_VERSION}" ]
 }
 
 @test "auto .nvmrc, lts/*" {
   local TARGET_VERSION="$(display_remote_version lts)"
   cd "${MY_DIR}"
   printf "lts/*\n" > .nvmrc
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "${TARGET_VERSION}" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "${TARGET_VERSION}" ]
 }
 
 @test "auto .nvmrc, lts/argon" {
   local TARGET_VERSION="$(display_remote_version lts)"
   cd "${MY_DIR}"
   printf "lts/argon\n" > .nvmrc
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "4.9.1" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "4.9.1" ]
 }
 
 @test "auto .nvmrc, sub directory" {
@@ -77,7 +65,6 @@ function teardown() {
   printf "v102.0.3\n" > .nvmrc
   mkdir -p sub-npmrc
   cd sub-npmrc
-  run n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto
-  [ "$status" -eq 0 ]
-  [ "${lines[${PAYLOAD_LINE}]}" = "102.0.3" ]
+  local output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  [ "${output}" = "102.0.3" ]
 }


### PR DESCRIPTION
# Pull Request

## Problem

Including `package.json` in `auto` blocks the use of the more explicit version control files further up the folder hierarchy, particularly in mono-repo layout. The `package.json` is not likely to as good a source of a specific version to install as the other version control files.

Related: #636 #639 #640 #637

## Solution

- `auto` scans for `package.json` only after looking for other (better) files up hierarchy.
- add `engine`
- rework tests to remove misuse of BATS `run` and make tests more maintainable

## ChangeLog

### Changed

- `auto` label now scans for `package.json` only if it can not find a version control file (#644)

### Added

- `engine` label to look for `engines.node` in `package.json` (as used by`auto`)
