### PR TITLE
Point to contributors on github rather than list subset

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,18 +7,8 @@
   "bugs": "https://github.com/tj/n/issues",
   "contributors": [
     {
-      "name": "Travis Webb",
-      "email": "me@traviswebb.com"
-    },
-    {
-      "name": "Nimit Kalra",
-      "email": "me@nimit.io",
-      "url": "https://nimit.io"
-    },
-    {
-      "name": "Troy Connor",
-      "email": "troy0820@gmail.com",
-      "url": "https://github.com/troy0820"
+      "name": "n Contributors",
+      "url": "https://github.com/tj/n/graphs/contributors"
     }
   ],
   "keywords": [


### PR DESCRIPTION
# Pull Request

## Problem

The contributors field in `package.json` lists a few of the past maintainers. It does not list all maintainers, or all collaborators. It isn't used by any tooling I am familiar with.

## Solution

Point to GitHub information on collaborators. Simple and self-updating.

If we want to credit past maintainers, an attribution in the README would be much more visible.