### PR TITLE
Add support for arrows keys when term in application mode

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -534,7 +534,8 @@ menu_select_cache_versions() {
       "$ESCAPE_SEQ")
         # Handle ESC sequences followed by other characters, i.e. arrow keys
         read -rsn 1 -t 1 tmp
-        if [[ "$tmp" == "[" ]]; then
+        # See "[" if terminal in normal mode, and "0" in application mode
+        if [[ "$tmp" == "[" || "$tmp" == "O" ]]; then
           read -rsn 1 -t 1 arrow
           case "$arrow" in
             "$UP")


### PR DESCRIPTION
# Pull Request

## Problem

The arrow keys do not work in the "menu" when `n` is run from PowerShell.

Fixes: #667

## Solution

The terminal may be in application mode or normal mode, and sends slightly different key sequences for special characters. Add test for the sequence seen in application mode.

## ChangeLog

- Add support for arrow key navigation of version menu from PowerShell on Mac (terminal in application mode)
