### PR TITLE
Add Emacs keyboard shortcuts for menu navigation

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -527,6 +527,8 @@ menu_select_cache_versions() {
   ESCAPE_SEQ=$'\033'
   UP=$'A'
   DOWN=$'B'
+  CTRLP=$'\020'
+  CTRLN=$'\016'
 
   while true; do
     read -rsn 1 key
@@ -572,12 +574,14 @@ menu_select_cache_versions() {
           display_versions_with_selected "${selected}"
         fi
         ;;
-      "k")
+      # Vim or Emacs 'up' key
+      "k"|"$CTRLP")
         clear
         selected="$(prev_version_installed "${selected}")"
         display_versions_with_selected "${selected}"
         ;;
-      "j")
+      # Vim or Emacs 'down' key
+      "j"|"$CTRLN")
         clear
         selected="$(next_version_installed "${selected}")"
         display_versions_with_selected "${selected}"


### PR DESCRIPTION
# Pull Request

## Problem

By default, both Bash and Zsh accept Emacs default short-keys, including up and down keys (`ctrl-p` and `ctrl-n`). It's a good idea to support those short-keys to make it easier for people who used to use those short-keys.

## Solution

I added both `ctrl-p` and `ctrl-n` keys to the switch-case.

## ChangeLog

Add support for Emacs up and down keys (`ctrl-p` and `ctrl-n`)
