### PR TITLE
engine and auto improvements

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -11,12 +11,15 @@ log() {
 }
 
 #
-# diag <type> <msg>
-# Same as log, but diagnostic to stderr rather than stdout.
+# verbose_log <type> <msg>
+# Can suppress with --quiet.
+# Like log but to stderr rather than stdout, so can also be used from "display" routines.
 #
 
-diag() {
-  >&2 printf "  ${SGR_CYAN}%10s${SGR_RESET} : ${SGR_FAINT}%s${SGR_RESET}\n" "$1" "$2"
+verbose_log() {
+  if [[ "${SHOW_VERBOSE_LOG}" == "true" ]]; then
+    >&2 printf "  ${SGR_CYAN}%10s${SGR_RESET} : ${SGR_FAINT}%s${SGR_RESET}\n" "$1" "$2"
+  fi
 }
 
 #
@@ -127,6 +130,7 @@ g_target_node=
 
 ACTIVATE=true
 ARCH=
+SHOW_VERBOSE_LOG="true"
 
 # ANSI escape codes
 # https://en.wikipedia.org/wiki/ANSI_escape_code
@@ -795,10 +799,11 @@ install() {
 }
 
 #
-# Set curl to quiet (silent) mode.
+# Be more silent.
 #
 
 set_quiet() {
+  SHOW_VERBOSE_LOG="false"
   command -v curl > /dev/null && CURL_OPTIONS+=( "--silent" ) && GET_SHOWS_PROGRESS="false"
 }
 
@@ -1035,13 +1040,13 @@ function tarball_url() {
 function get_file_node_version() {
   g_target_node=
   local filepath="$1"
-  diag "found" "${filepath}"
+  verbose_log "found" "${filepath}"
   # read returns a non-zero status but does still work if there is no line ending
   local version
   <"${filepath}" read -r version
   # trim possible trailing \d from a Windows created file
   version="${version%%[[:space:]]}"
-  diag "read" "${version}"
+  verbose_log "read" "${version}"
   g_target_node="${version}"
 }
 
@@ -1053,13 +1058,13 @@ function get_file_node_version() {
 function get_package_engine_version() {
   g_target_node=
   local filepath="$1"
-  diag "found" "${filepath}"
+  verbose_log "found" "${filepath}"
   command -v node &> /dev/null || abort "an active version of node is required to read 'engines' from package.json"
   local range
   range="$(node -e "package = require('${filepath}'); if (package && package.engines && package.engines.node) console.log(package.engines.node)")"
-  diag "read" "${range}"
+  verbose_log "read" "${range}"
   if [[ -z "${range}" || "*" == "${range}" ]]; then
-    diag "target" "current"
+    verbose_log "target" "current"
     g_target_node="current"
     return
   fi
@@ -1074,10 +1079,10 @@ function get_package_engine_version() {
       \~) [[ "${version}" =~ ^([0-9]+\.[0-9]+)\.[0-9]+$ ]] && version="${BASH_REMATCH[1]}" ;;
       ^) [[ "${version}" =~ ^([0-9]+) ]] && version="${BASH_REMATCH[1]}" ;;
     esac
-    diag "target" "${version}"
+    verbose_log "target" "${version}"
   else
     command -v npx &> /dev/null || abort "an active version of npx is required to use complex 'engine' ranges from package.json"
-    diag "resolving" "${range}"
+    verbose_log "resolving" "${range}"
     local version_per_line="$(n lsr --all)"
     local versions_one_line=$(echo "${version_per_line}" | tr '\n' ' ')
     # Using semver@7 so works with older versions of node.
@@ -1095,10 +1100,10 @@ function get_package_engine_version() {
 function get_nvmrc_version() {
   g_target_node=
   local filepath="$1"
-  diag "found" "${filepath}"
+  verbose_log "found" "${filepath}"
   local version
   <"${filepath}" read -r version
-  diag "read" "${version}"
+  verbose_log "read" "${version}"
   # Translate from nvm aliases
   case "${version}" in
     lts/\*) version="lts" ;;

--- a/bin/n
+++ b/bin/n
@@ -387,7 +387,7 @@ Options:
   -V, --version         Output version of n
   -h, --help            Display help information
   -p, --preserve        Preserve npm and npx during install of Node.js
-  -q, --quiet           Disable curl output (if available)
+  -q, --quiet           Disable curl output (if available), and log messages processing "auto" and "engine" labels.
   -d, --download        Download only
   -a, --arch            Override system architecture
   --all                 ls-remote displays all matches instead of last 20

--- a/bin/n
+++ b/bin/n
@@ -387,7 +387,7 @@ Options:
   -V, --version         Output version of n
   -h, --help            Display help information
   -p, --preserve        Preserve npm and npx during install of Node.js
-  -q, --quiet           Disable curl output (if available), and log messages processing "auto" and "engine" labels.
+  -q, --quiet           Disable curl output. Disable log messages processing "auto" and "engine" labels.
   -d, --download        Download only
   -a, --arch            Override system architecture
   --all                 ls-remote displays all matches instead of last 20

--- a/bin/n
+++ b/bin/n
@@ -3,11 +3,20 @@
 # Disabled "Declare and assign separately to avoid masking return values": https://github.com/koalaman/shellcheck/wiki/SC2155
 
 #
-# Log <type> <msg>
+# log <type> <msg>
 #
 
 log() {
   printf "  ${SGR_CYAN}%10s${SGR_RESET} : ${SGR_FAINT}%s${SGR_RESET}\n" "$1" "$2"
+}
+
+#
+# diag <type> <msg>
+# Same as log, but diagnostic to stderr rather than stdout.
+#
+
+diag() {
+  >&2 printf "  ${SGR_CYAN}%10s${SGR_RESET} : ${SGR_FAINT}%s${SGR_RESET}\n" "$1" "$2"
 }
 
 #
@@ -1026,13 +1035,13 @@ function tarball_url() {
 function get_file_node_version() {
   g_target_node=
   local filepath="$1"
-  log "found" "${filepath}"
+  diag "found" "${filepath}"
   # read returns a non-zero status but does still work if there is no line ending
   local version
   <"${filepath}" read -r version
   # trim possible trailing \d from a Windows created file
   version="${version%%[[:space:]]}"
-  log "read" "${version}"
+  diag "read" "${version}"
   g_target_node="${version}"
 }
 
@@ -1044,13 +1053,13 @@ function get_file_node_version() {
 function get_package_engine_version() {
   g_target_node=
   local filepath="$1"
-  log "found" "${filepath}"
+  diag "found" "${filepath}"
   command -v node &> /dev/null || abort "an active version of node is required to read 'engines' from package.json"
   local range
   range="$(node -e "package = require('${filepath}'); if (package && package.engines && package.engines.node) console.log(package.engines.node)")"
-  log "read" "${range}"
+  diag "read" "${range}"
   if [[ -z "${range}" || "*" == "${range}" ]]; then
-    log "target" "current"
+    diag "target" "current"
     g_target_node="current"
     return
   fi
@@ -1065,10 +1074,10 @@ function get_package_engine_version() {
       \~) [[ "${version}" =~ ^([0-9]+\.[0-9]+)\.[0-9]+$ ]] && version="${BASH_REMATCH[1]}" ;;
       ^) [[ "${version}" =~ ^([0-9]+) ]] && version="${BASH_REMATCH[1]}" ;;
     esac
-    log "target" "${version}"
+    diag "target" "${version}"
   else
     command -v npx &> /dev/null || abort "an active version of npx is required to use complex 'engine' ranges from package.json"
-    log "resolving" "${range}"
+    diag "resolving" "${range}"
     local version_per_line="$(n lsr --all)"
     local versions_one_line=$(echo "${version_per_line}" | tr '\n' ' ')
     # Using semver@7 so works with older versions of node.
@@ -1086,10 +1095,10 @@ function get_package_engine_version() {
 function get_nvmrc_version() {
   g_target_node=
   local filepath="$1"
-  log "found" "${filepath}"
+  diag "found" "${filepath}"
   local version
   <"${filepath}" read -r version
-  log "read" "${version}"
+  diag "read" "${version}"
   # Translate from nvm aliases
   case "${version}" in
     lts/\*) version="lts" ;;
@@ -1157,15 +1166,6 @@ function get_auto_version() {
 function get_latest_resolved_version() {
   g_target_node=
   local version=${1}
-  # auto and engine make sense for local use and not much for ls-remote, so handled here rather than display_remote_versions
-  if [[ "${version}" = "auto" ]]; then
-    get_auto_version || return 2
-    version="${g_target_node}"
-  fi
-  if [[ "${version}" = "engine" ]]; then
-    get_engine_version || return 2
-    version="${g_target_node}"
-  fi
   simple_version=${version#node/} # Only place supporting node/ [sic]
   if is_exact_numeric_version "${simple_version}"; then
     # Just numbers, already resolved, no need to lookup first.
@@ -1213,10 +1213,21 @@ function display_remote_versions() {
   update_mirror_settings_for_version "${version}"
   local match='.'
   local match_count="${N_MAX_REMOTE_MATCHES}"
+
+  # Transform some labels before processing further.
   if is_node_support_version "${version}"; then
     version="$(display_latest_node_support_alias "${version}")"
     match_count=1
+  elif [[ "${version}" = "auto" ]]; then
+    # suppress stdout logging so lsr layout same as usual for scripting
+    get_auto_version || return 2
+    version="${g_target_node}"
+  elif [[ "${version}" = "engine" ]]; then
+    # suppress stdout logging so lsr layout same as usual for scripting
+    get_engine_version || return 2
+    version="${g_target_node}"
   fi
+
   if [[ -z "${version}" ]]; then
     match='.'
   elif [[ "${version}" = "lts" || "${version}" = "stable" ]]; then
@@ -1562,7 +1573,7 @@ else
       lsr|ls-remote|list-remote) shift; display_remote_versions "$1"; exit ;;
       uninstall) uninstall_installed; exit ;;
       i|install) shift; install "$1"; exit ;;
-      N_TEST_DISPLAY_LATEST_RESOLVED_VERSION) shift; get_latest_resolved_version "$1" > /dev/null; echo "${g_target_node}"; exit ;;
+      N_TEST_DISPLAY_LATEST_RESOLVED_VERSION) shift; get_latest_resolved_version "$1" > /dev/null || exit 2; echo "${g_target_node}"; exit ;;
       *) install "$1"; exit ;;
     esac
     shift

--- a/test/tests/version-auto-priority.bats
+++ b/test/tests/version-auto-priority.bats
@@ -33,51 +33,51 @@ function setup() {
 
 @test ".n-node-version first" {
   cd "${MY_DIR}"
-  echo "401.0.1" > .n-node-version
-  echo "401.0.2" > .node-version
-  echo "401.0.3" > .nvmrc
-  echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
+  echo "8.1.4" > .n-node-version
+  echo "8.2.0" > .node-version
+  echo "8.3.0" > .nvmrc
+  echo '{ "engines" : { "node" : "v8.4.0" } }' > package.json
 
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "401.0.1"
+  assert_equal "${output}" "8.1.4"
 }
 
 @test ".node-version second" {
   cd "${MY_DIR}"
-  echo "401.0.2" > .node-version
-  echo "401.0.3" > .nvmrc
-  echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
+  echo "8.2.0" > .node-version
+  echo "8.3.0" > .nvmrc
+  echo '{ "engines" : { "node" : "v8.4.0" } }' > package.json
 
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "401.0.2"
+  assert_equal "${output}" "8.2.0"
 }
 
 @test ".nvmrc third" {
   cd "${MY_DIR}"
-  echo "401.0.3" > .nvmrc
-  echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
+  echo "8.3.0" > .nvmrc
+  echo '{ "engines" : { "node" : "v8.4.0" } }' > package.json
 
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "401.0.3"
+  assert_equal "${output}" "8.3.0"
 }
 
 @test ".package.json last" {
   cd "${MY_DIR}"
-  echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
+  echo '{ "engines" : { "node" : "v8.4.0" } }' > package.json
 
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "401.0.4"
+  assert_equal "${output}" "8.4.0"
 }
 
 @test ".package.json last, after parent scanning" {
   cd "${MY_DIR}"
-  echo "401.0.2" > .node-version
+  echo "8.2.0" > .node-version
   mkdir package
   cd package
-  echo '{ "engines" : { "node" : "v401.0.4" } }' > package.json
+  echo '{ "engines" : { "node" : "v8.4.0" } }' > package.json
 
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "401.0.2"
+  assert_equal "${output}" "8.2.0"
 
   rm package.json
   cd ..

--- a/test/tests/version-resolve-auto-engine.bats
+++ b/test/tests/version-resolve-auto-engine.bats
@@ -36,39 +36,39 @@ function write_engine() {
   # Dummy test so setupAll displayed while running first setup
 }
 
-@test "auto engine, 104.0.1" {
+@test "auto engine, 8.9.0" {
   cd "${MY_DIR}"
-  write_engine "103.0.1"
+  write_engine "8.9.0"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "103.0.1"
+  assert_equal "${output}" "8.9.0"
 }
 
-@test "auto engine, v104.0.2" {
+@test "auto engine, v8.9.1" {
   cd "${MY_DIR}"
-  write_engine "v104.0.2"
+  write_engine "v8.9.1"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "104.0.2"
+  assert_equal "${output}" "8.9.1"
 }
 
-@test "auto engine, =104.0.3" {
+@test "auto engine, =8.9.2" {
   cd "${MY_DIR}"
-  write_engine "=103.0.3"
+  write_engine "=8.9.2"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "103.0.3"
+  assert_equal "${output}" "8.9.2"
 }
 
-@test "auto engine, =v104.0.4" {
+@test "auto engine, =v8.9.3" {
   cd "${MY_DIR}"
-  write_engine "=v104.0.4"
+  write_engine "=v8.9.3"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "104.0.4"
+  assert_equal "${output}" "8.9.3"
 }
 
-@test "engine, =v104.0.5" {
+@test "engine, =v8.9.4" {
   cd "${MY_DIR}"
-  write_engine "=v104.0.5"
+  write_engine "=v8.9.4"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION engine)"
-  assert_equal "${output}" "104.0.5"
+  assert_equal "${output}" "8.9.4"
 }
 
 @test "auto engine, >1" {

--- a/test/tests/version-resolve-auto-file.bats
+++ b/test/tests/version-resolve-auto-file.bats
@@ -1,6 +1,5 @@
 #!/usr/bin/env bats
 
-# Note: full semver is resolved without lookup, so can use arbitrary versions for testing like 999.999.999
 # Not testing all the permutations on both files, as know they are currenly implemented using same code!
 
 load shared-functions
@@ -34,46 +33,46 @@ function setup() {
 
 @test "auto .n-node-version, no eol" {
   cd "${MY_DIR}"
-  printf "101.0.1" > .n-node-version
+  printf "8.1.0" > .n-node-version
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "101.0.1"
+  assert_equal "${output}" "8.1.0"
 }
 
 @test "auto .n-node-version, unix eol" {
   cd "${MY_DIR}"
-  printf "101.0.2\n" > .n-node-version
+  printf "8.1.1\n" > .n-node-version
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "101.0.2"
+  assert_equal "${output}" "8.1.1"
 }
 
 @test "auto .n-node-version, Windows eol" {
   cd "${MY_DIR}"
-  printf "101.0.3\r\n" > .n-node-version
+  printf "8.1.2\r\n" > .n-node-version
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "101.0.3"
+  assert_equal "${output}" "8.1.2"
 }
 
 @test "auto .n-node-version, leading v" {
   cd "${MY_DIR}"
-  printf "v101.0.4\n" > .n-node-version
+  printf "v8.1.3\n" > .n-node-version
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "101.0.4"
+  assert_equal "${output}" "8.1.3"
 }
 
 @test "auto .n-node-version, first line only" {
   cd "${MY_DIR}"
-  printf "101.0.5\nmore text\n" > .n-node-version
+  printf "8.1.4\nmore text\n" > .n-node-version
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "101.0.5"
+  assert_equal "${output}" "8.1.4"
 }
 
 @test "auto .n-node-version, from sub directory" {
   cd "${MY_DIR}"
-  printf "101.0.6\nmore text\n" > .n-node-version
+  printf "8.2.0\n" > .n-node-version
   mkdir -p sub6
   cd sub6
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "101.0.6"
+  assert_equal "${output}" "8.2.0"
 }
 
 @test "auto .node-version, partial version lookup" {
@@ -86,10 +85,10 @@ function setup() {
 
 @test "auto .node-version, from sub directory" {
   cd "${MY_DIR}"
-  printf "101.0.7\nmore text\n" > .n-node-version
+  printf "8.2.1\n" > .n-node-version
   mkdir -p sub7
   cd sub7
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "101.0.7"
+  assert_equal "${output}" "8.2.1"
 }
 

--- a/test/tests/version-resolve-auto-nvmrc.bats
+++ b/test/tests/version-resolve-auto-nvmrc.bats
@@ -1,7 +1,5 @@
 #!/usr/bin/env bats
 
-# Note: full semver is resolved without lookup, so can use arbitrary versions for testing like 999.999.999
-
 load shared-functions
 load '../../node_modules/bats-support/load'
 load '../../node_modules/bats-assert/load'
@@ -26,16 +24,16 @@ function setup() {
 
 @test "auto .nvmrc, numeric" {
   cd "${MY_DIR}"
-  printf "102.0.1\n" > .nvmrc
+  printf "8.10.0\n" > .nvmrc
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "102.0.1"
+  assert_equal "${output}" "8.10.0"
 }
 
 @test "auto .nvmrc, numeric with leading v" {
   cd "${MY_DIR}"
-  printf "v102.0.2\n" > .nvmrc
+  printf "v8.11.0\n" > .nvmrc
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "102.0.2"
+  assert_equal "${output}" "8.11.0"
 }
 
 @test "auto .nvmrc, node" {
@@ -64,9 +62,9 @@ function setup() {
 
 @test "auto .nvmrc, sub directory" {
   cd "${MY_DIR}"
-  printf "v102.0.3\n" > .nvmrc
+  printf "v8.11.1\n" > .nvmrc
   mkdir -p sub-npmrc
   cd sub-npmrc
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
-  assert_equal "${output}" "102.0.3"
+  assert_equal "${output}" "8.11.1"
 }


### PR DESCRIPTION
# Pull Request

## Problem

The `engine` and `auto` labels do not work for `ls-remote` (and are not documented as being special in this way).

Issues: #674

## Solution

Refactor the handling of `engine` and `auto` so also works for `ls-remote`. 

To allow logging from "display" routines the diagnostic output during the file scanning for `engine` and `auto` was moved from stdout to stderr, and can now be suppressed with `--quiet`.

This allows code like:

```
desired_version=$(N_MAX_REMOTE_MATCHES=1 n --quiet ls-remote auto)
```

## ChangeLog

- add: `ls-remote` supports `engine` and `auto` labels
- add: reduce `engine` and `auto` logging with `--quiet`
- changed: diagnostic logging during processing of `engine` and `auto` written to stderr rather than stdout
