### PR TITLE
Add platforms section and include WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ Node.js version management: no subshells, no profile setup, no convoluted API, j
 
 ![usage animation](https://nimit.io/images/n/n.gif)
 
-(Note: `n` is not supported natively on Windows.)
-
 - [`n` – Interactively Manage Your Node.js Versions](#n--interactively-manage-your-nodejs-versions)
+    - [Supported Platforms](#supported-platforms)
     - [Installation](#installation)
         - [Third Party Installers](#third-party-installers)
     - [Installing Node.js Versions](#installing-nodejs-versions)
@@ -24,6 +23,13 @@ Node.js version management: no subshells, no profile setup, no convoluted API, j
     - [Custom Architecture](#custom-architecture)
     - [Optional Environment Variables](#optional-environment-variables)
     - [How It Works](#how-it-works)
+
+## Supported Platforms
+
+`n` is supported on macOS, Linux, including with Windows Subsystem for Linux, and various other unix-like systems.
+It is written as a BASH script but does not require you to use BASH as your command shell.
+
+`n` does not work in native shells on Microsoft Windows (like PowerShell), or Git for Windows BASH, or with the Cygwin DLL.
 
 ## Installation
 


### PR DESCRIPTION
# Pull Request

## Problem

`n` works fine in WSL, and is even mentioned as an alternative Node.js version manager on the WSL page, but support is not mentioned in the README.

WSL: #511

People try installing `n` from other Microsoft Windows shells.

!win32: #326 #358 #419 #435 #491 #656 

## Solution

Add a Supported Platforms section to clarify the support.

Be explicit about other scenarios on Microsoft Windows to hopefully reduce people caught out by unsupported shells.

## ChangeLog

- Add WSL support to README
