### PR TITLE
Add support for opt-in download to exec and run

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -115,9 +115,9 @@ if [ -n "$HTTP_USER" ];then
   if [ -z "$HTTP_PASSWORD" ]; then
     abort "Must specify HTTP_PASSWORD when supplying HTTP_USER"
   fi
-  CURL_OPTIONS+=("-u $HTTP_USER:$HTTP_PASSWORD")
-  WGET_OPTIONS+=("--http-password=$HTTP_PASSWORD"
-                "--http-user=$HTTP_USER")
+  CURL_OPTIONS+=( "-u $HTTP_USER:$HTTP_PASSWORD" )
+  WGET_OPTIONS+=( "--http-password=$HTTP_PASSWORD"
+                "--http-user=$HTTP_USER" )
 elif [ -n "$HTTP_PASSWORD" ]; then
   abort "Must specify HTTP_USER when supplying HTTP_PASSWORD"
 fi
@@ -1550,12 +1550,12 @@ while [[ $# -ne 0 ]]; do
     --lts) display_remote_versions lts; exit ;;
     -a|--arch) shift; set_arch "$1";; # set arch and continue
     exec|run|as|use)
-      unprocessed_args+=("$1")
+      unprocessed_args+=( "$1" )
       positional_arg="true"
       ;;
     *)
       if [[ "${positional_arg}" == "true" ]]; then
-        unprocessed_args+=("$@")
+        unprocessed_args+=( "$@" )
         break
       fi
       unprocessed_args+=( "$1" )

--- a/bin/n
+++ b/bin/n
@@ -1528,6 +1528,7 @@ function show_diagnostics() {
 # which feel pretty natural.
 
 unprocessed_args=()
+positional_arg="false"
 
 while [[ $# -ne 0 ]]; do
   case "$1" in
@@ -1545,9 +1546,17 @@ while [[ $# -ne 0 ]]; do
     --stable) display_remote_versions lts; exit ;; # [sic] old terminology
     --lts) display_remote_versions lts; exit ;;
     -a|--arch) shift; set_arch "$1";; # set arch and continue
-    exec) unprocessed_args=("$@"); break ;;
-    run|as|use) unprocessed_args=("$@"); break ;;
-    *) unprocessed_args+=( "$1" ) ;;
+    exec|run|as|use)
+      unprocessed_args+=("$1")
+      positional_arg="true"
+      ;;
+    *)
+      if [[ "${positional_arg}" == "true" ]]; then
+        unprocessed_args+=("$@")
+        break
+      fi
+      unprocessed_args+=( "$1" )
+      ;;
   esac
   shift
 done

--- a/bin/n
+++ b/bin/n
@@ -128,7 +128,7 @@ g_active_node=
 # set by various lookups to allow mixed logging and return value from function, especially for engine and node
 g_target_node=
 
-ACTIVATE=true
+DOWNLOAD=false # set to opt-out of activate (install), and opt-in to download (run, exec)
 ARCH=
 SHOW_VERBOSE_LOG="true"
 
@@ -765,7 +765,7 @@ install() {
 
   if test -d "$dir"; then
     if [[ ! -e "$dir/n.lock" ]] ; then
-      if "$ACTIVATE" ; then
+      if [[ "$DOWNLOAD" == "false" ]] ; then
         activate "${g_mirror_folder_name}/${version}"
       fi
       exit
@@ -793,7 +793,7 @@ install() {
 
   disable_pax_mprotect bin/node
 
-  if "$ACTIVATE" ; then
+  if [[ "$DOWNLOAD" == "false" ]]; then
     activate "${g_mirror_folder_name}/$version"
   fi
 }
@@ -894,6 +894,9 @@ function find_cached_version() {
 
   update_mirror_settings_for_version "$1"
   g_cached_version="${CACHE_DIR}/${g_mirror_folder_name}/${version}"
+  if [[ ! -d "${g_cached_version}" && "${DOWNLOAD}" == "true" ]]; then
+    install "${version}"
+  fi
   [[ -d "${g_cached_version}" ]] || abort "'$1' (${version}) not in downloads cache"
 }
 
@@ -1536,7 +1539,7 @@ while [[ $# -ne 0 ]]; do
     -V|--version) display_n_version ;;
     -h|--help|help) display_help; exit ;;
     -q|--quiet) set_quiet ;;
-    -d|--download) ACTIVATE=false ;;
+    -d|--download) DOWNLOAD="true" ;;
     --insecure) set_insecure ;;
     -p|--preserve) N_PRESERVE_NPM="true" ;;
     --no-preserve) N_PRESERVE_NPM="" ;;

--- a/bin/n
+++ b/bin/n
@@ -388,7 +388,7 @@ Options:
   -h, --help            Display help information
   -p, --preserve        Preserve npm and npx during install of Node.js
   -q, --quiet           Disable curl output. Disable log messages processing "auto" and "engine" labels.
-  -d, --download        Download only
+  -d, --download        Download if necessary, and don't make active
   -a, --arch            Override system architecture
   --all                 ls-remote displays all matches instead of last 20
   --insecure            Turn off certificate checking for https requests (may be needed from behind a proxy server)

--- a/test/tests/run-which.bats
+++ b/test/tests/run-which.bats
@@ -11,12 +11,12 @@ function setup_file() {
   export N_PREFIX="${tmpdir}/n/test/run-which"
   n --download 4.9.1
   n --download lts
+  # using "latest" for download tests with run and exec
 }
 
 function teardown_file() {
   rm -rf "${N_PREFIX}"
 }
-
 
 @test "setupAll for run/which/exec # (2 installs)" {
   # Dummy test so setupAll displayed while running first setup
@@ -37,18 +37,15 @@ function teardown_file() {
   assert_equal "$output" "${N_PREFIX}/n/versions/node/4.9.1/bin/node"
 }
 
-
 @test "n bin v4.9.1" {
   output="$(n bin v4.9.1)"
   assert_equal "$output" "${N_PREFIX}/n/versions/node/4.9.1/bin/node"
 }
 
-
 @test "n which argon" {
   output="$(n which argon)"
   assert_equal "$output" "${N_PREFIX}/n/versions/node/4.9.1/bin/node"
 }
-
 
 @test "n which lts" {
   output="$(n which lts)"
@@ -64,26 +61,29 @@ function teardown_file() {
   assert_equal "$output" "v4.9.1"
 }
 
-
 @test "n run lts" {
   output="$(n run lts --version)"
   local LTS_VERSION="$(display_remote_version lts)"
   assert_equal "$output" "v${LTS_VERSION}"
 }
 
-
 @test "n use 4" {
   output="$(n use 4 --version)"
   assert_equal "$output" "v4.9.1"
 }
-
 
 @test "n as 4" {
   output="$(n as 4 --version)"
   assert_equal "$output" "v4.9.1"
 }
 
-
+@test "n run --download latest" {
+  n rm latest || true
+  n run --download latest --version
+  output="$(n run latest --version)"
+  local LATEST_VERSION="$(display_remote_version latest)"
+  assert_equal "$output" "v${LATEST_VERSION}"
+}
 
 
 # n exec
@@ -93,15 +93,21 @@ function teardown_file() {
   assert_equal "$output" "v4.9.1"
 }
 
-
 @test "n exec 4 npm" {
   output="$(n exec 4 npm --version)"
   assert_equal "$output" "2.15.11"
 }
 
-
 @test "n exec lts" {
   output="$(n exec lts node --version)"
   local LTS_VERSION="$(display_remote_version lts)"
   assert_equal "$output" "v${LTS_VERSION}"
+}
+
+@test "n exec -d latest" {
+  n rm latest || true
+  n exec -d latest node --version
+  output="$(n exec latest node --version)"
+  local LATEST_VERSION="$(display_remote_version latest)"
+  assert_equal "$output" "v${LATEST_VERSION}"
 }


### PR DESCRIPTION
# Pull Request

## Problem

It is inconvenient to use `n run` and `n exec` in CI situations where the version may not have already been downloaded. 

Workarounds are to have some extra script steps or setup to always install, or conditionally install. But this may be difficult to arrange in an npm run script, for example.

Resolves #647

## Solution

Allow use of the existing `-d, --download` flag with `run` and `exec` to download the target version, if necessary.

This is a slightly different use of the flag than with an install, but I didn't come up with a better flag and I think the usage is clear enough in both cases.

```
n --download lts
n run --download latest myScript.js
```

Example usage:

```
% node --version
v10.24.1
% n run lts --version

  Error: 'lts' (14.17.6) not in downloads cache

% n run -d lts --version
  installing : node-v14.17.6
       mkdir : /usr/local/n/versions/node/14.17.6
       fetch : https://nodejs.org/dist/v14.17.6/node-v14.17.6-darwin-x64.tar.xz
v14.17.6
% node --version
v10.24.1
```

(A side-effect of the implementation is that `--download` is also supported for `which`!)

## ChangeLog

- add support for `--download` option to `run` and `exec` to download the target version, if necessary
