### PR TITLE
Add support for corepack

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -701,10 +701,10 @@ activate() {
   # Copy just node, in case user has installed global npm modules into cache.
   cp -f "$dir/bin/node" "$N_PREFIX/bin"
   [[ -e "$dir/bin/node-waf" ]] && cp -f "$dir/bin/node-waf" "$N_PREFIX/bin" # v0.8.x
-  [[ -e "$dir/bin/corepack" ]] && cp -f "$dir/bin/corepack" "$N_PREFIX/bin"
+  [[ -e "$dir/bin/corepack" ]] && cp -fR "$dir/bin/corepack" "$N_PREFIX/bin"
   if [[ -z "${N_PRESERVE_NPM}" ]]; then
-    [[ -e "$dir/bin/npm" ]] && cp -f "$dir/bin/npm" "$N_PREFIX/bin"
-    [[ -e "$dir/bin/npx" ]] && cp -f "$dir/bin/npx" "$N_PREFIX/bin"
+    [[ -e "$dir/bin/npm" ]] && cp -fR "$dir/bin/npm" "$N_PREFIX/bin"
+    [[ -e "$dir/bin/npx" ]] && cp -fR "$dir/bin/npx" "$N_PREFIX/bin"
   fi
 
   # include

--- a/bin/n
+++ b/bin/n
@@ -698,10 +698,10 @@ activate() {
   mkdir -p "$N_PREFIX/bin"
   # Remove old node to avoid potential problems with firewall getting confused on Darwin by overwrite.
   rm -f "$N_PREFIX/bin/node"
-  # Copy just node, in case user has installed global npm modules into cache.
+  # Copy bin items by hand, in case user has installed global npm modules into cache.
   cp -f "$dir/bin/node" "$N_PREFIX/bin"
   [[ -e "$dir/bin/node-waf" ]] && cp -f "$dir/bin/node-waf" "$N_PREFIX/bin" # v0.8.x
-  [[ -e "$dir/bin/corepack" ]] && cp -fR "$dir/bin/corepack" "$N_PREFIX/bin"
+  [[ -e "$dir/bin/corepack" ]] && cp -fR "$dir/bin/corepack" "$N_PREFIX/bin" # from 16.9.0
   if [[ -z "${N_PRESERVE_NPM}" ]]; then
     [[ -e "$dir/bin/npm" ]] && cp -fR "$dir/bin/npm" "$N_PREFIX/bin"
     [[ -e "$dir/bin/npx" ]] && cp -fR "$dir/bin/npx" "$N_PREFIX/bin"

--- a/bin/n
+++ b/bin/n
@@ -688,6 +688,11 @@ activate() {
     # Copy just npm, skipping possible added global modules after download. Clean copy to avoid version change problems.
     clean_copy_folder "$dir/lib/node_modules/npm" "$N_PREFIX/lib/node_modules/npm"
   fi
+  # Takes same steps for corepack (experimental in node 16.9.0) as for npm, to avoid version problems.
+  if [[ -e "$dir/bin/corepack" ]]; then
+    mkdir -p "$N_PREFIX/lib/node_modules"
+    clean_copy_folder "$dir/lib/node_modules/corepack" "$N_PREFIX/lib/node_modules/corepack"
+  fi
 
   # bin
   mkdir -p "$N_PREFIX/bin"
@@ -696,9 +701,10 @@ activate() {
   # Copy just node, in case user has installed global npm modules into cache.
   cp -f "$dir/bin/node" "$N_PREFIX/bin"
   [[ -e "$dir/bin/node-waf" ]] && cp -f "$dir/bin/node-waf" "$N_PREFIX/bin" # v0.8.x
+  [[ -e "$dir/bin/corepack" ]] && cp -f "$dir/bin/corepack" "$N_PREFIX/bin"
   if [[ -z "${N_PRESERVE_NPM}" ]]; then
-    [[ -e "$dir/bin/npm" ]] && cp -fR "$dir/bin/npm" "$N_PREFIX/bin"
-    [[ -e "$dir/bin/npx" ]] && cp -fR "$dir/bin/npx" "$N_PREFIX/bin"
+    [[ -e "$dir/bin/npm" ]] && cp -f "$dir/bin/npm" "$N_PREFIX/bin"
+    [[ -e "$dir/bin/npx" ]] && cp -f "$dir/bin/npx" "$N_PREFIX/bin"
   fi
 
   # include
@@ -1329,9 +1335,11 @@ uninstall_installed() {
   delete_with_echo "${N_PREFIX}/bin/node"
   delete_with_echo "${N_PREFIX}/bin/npm"
   delete_with_echo "${N_PREFIX}/bin/npx"
+  delete_with_echo "${N_PREFIX}/bin/corepack"
   delete_with_echo "${N_PREFIX}/include/node"
   delete_with_echo "${N_PREFIX}/lib/dtrace/node.d"
   delete_with_echo "${N_PREFIX}/lib/node_modules/npm"
+  delete_with_echo "${N_PREFIX}/lib/node_modules/corepack"
   delete_with_echo "${N_PREFIX}/share/doc/node"
   delete_with_echo "${N_PREFIX}/share/man/man1/node.1"
   delete_with_echo "${N_PREFIX}/share/systemtap/tapset/node.stp"

--- a/bin/n
+++ b/bin/n
@@ -689,7 +689,7 @@ activate() {
     clean_copy_folder "$dir/lib/node_modules/npm" "$N_PREFIX/lib/node_modules/npm"
   fi
   # Takes same steps for corepack (experimental in node 16.9.0) as for npm, to avoid version problems.
-  if [[ -e "$dir/bin/corepack" ]]; then
+  if [[ -e "$dir/lib/node_modules/corepack" ]]; then
     mkdir -p "$N_PREFIX/lib/node_modules"
     clean_copy_folder "$dir/lib/node_modules/corepack" "$N_PREFIX/lib/node_modules/corepack"
   fi


### PR DESCRIPTION
# Pull Request

## Problem

Node v16.9.0 added the `corepack` command, which has a symlink at `bin/corepack` and folder at `lib/node_modules/corepack`. These do not get activated (copied) when installing Node.js with `n`.

https://nodejs.org/dist/latest-v16.x/docs/api/corepack.html

Currently marked as experimental, so subject to change!

(Note: we currently only copy known binaries to make it less likely that using `n exec` and installing npm global modules pollutes installing from the nominally pure cached versions of Node.js. The downside is we don't copy new files for free, like Corepack! No good deed goes unpunished...)

## Solution

Add support for Corepack during install. Since Corepack is shipping in `node_modules`, take the same paranoid steps as with `npm` to avoid stale files left over from version changes.

Following the same pattern as with `npm`, remove when run `n uninstall`.  This is not correct if the user has manually installed Corepack, but that is no longer the preferred option from its README:

> We do acknowledge the irony and overhead of using npm to install Corepack, which is at least part of why the preferred option is to use the Corepack version that will be distributed along with Node itself.

https://github.com/nodejs/corepack

## ChangeLog

- add support for Corepack (which was added to Node.js in v16.9.0)
