### PR TITLE
Fail for blank target from auto (or engine) version file

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -1143,7 +1143,7 @@ function get_engine_version() {
     break
   done
   [[ -n "${parent}" ]] || abort "${error_message}"
-  [[ -n "${g_target_node}" ]] || abort "did not find supported versions of node in 'engines' field of package.json"
+  [[ -n "${g_target_node}" ]] || abort "did not find supported version of node in 'engines' field of package.json"
 }
 
 #

--- a/bin/n
+++ b/bin/n
@@ -1071,7 +1071,8 @@ function get_package_engine_version() {
   local range
   range="$(node -e "package = require('${filepath}'); if (package && package.engines && package.engines.node) console.log(package.engines.node)")"
   verbose_log "read" "${range}"
-  if [[ -z "${range}" || "*" == "${range}" ]]; then
+  [[ -n "${range}" ]] || return 2
+  if [[ "*" == "${range}" ]]; then
     verbose_log "target" "current"
     g_target_node="current"
     return
@@ -1142,6 +1143,7 @@ function get_engine_version() {
     break
   done
   [[ -n "${parent}" ]] || abort "${error_message}"
+  [[ -n "${g_target_node}" ]] || abort "did not find supported versions of node in 'engines' field of package.json"
 }
 
 #
@@ -1169,6 +1171,7 @@ function get_auto_version() {
   done
   # Fallback to package.json
   [[ -n "${parent}" ]] || get_engine_version "no file found for auto version (.n-node-version, .node-version, .nvmrc, or package.json)"
+  [[ -n "${g_target_node}" ]] || abort "file found for auto did not contain target version of node"
 }
 
 #


### PR DESCRIPTION
# Pull Request

## Problem

Using `auto` and `engine` will fallback to `current` if the found version file does not contain a target version. This could be due to an empty version file, but the more likely situation is a `package.json` with no `engines` field. This is a bit surprising and not particularly useful.

There is a technical argument for `current` if there is an `engines` field with a `node` field which is empty, but even then installing the current version of node is not all that useful.

> And, like with dependencies, if you don't specify the version (or if you specify "*" as the version), then any version of node will do.

https://docs.npmjs.com/cli/v7/configuring-npm/package-json#engines

Resolves: #692

## Solution

Display an error if the target version is missing (blank).

```
% echo "" >>  .node-version
% n auto
       found : /Users/john/Documents/Sandpits/n/issues/692/.node-version
        read : 

  Error: file found for auto did not contain target version of node

% rm .node-version

% npm init -y
% n engine
       found : /Users/john/Documents/Sandpits/n/issues/692/package.json
        read : 

  Error: did not find supported versions of node in 'engines' field of package.json

```

## ChangeLog

- changed: display error if version missing in version file for `auto` and `engine` (rather than fallback to `current`)
