### PR TITLE
Explicitly tell tar to read from stdin

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -789,7 +789,7 @@ install() {
   cd "${dir}" || abort "Failed to cd to ${dir}"
 
   log fetch "$url"
-  do_get "${url}" | tar "$tarflag" --strip-components=1 --no-same-owner
+  do_get "${url}" | tar "$tarflag" --strip-components=1 --no-same-owner -f -
   if [[ "${PIPESTATUS[0]}" -ne 0 ]]; then
     abort "failed to download archive for $version"
   fi


### PR DESCRIPTION
# Pull Request

## Problem

`libarchive` flavour of tar does not read from standard input without explicit flags, and `n` install fails. This is as per POSIX.

See #696

(Note: did not reproduce on macOS, but was able to reproduce on Ubuntu.)

## Solution

Add `-f -` to tar flags, which works with GNU tar and `libarchive` tar.

## ChangeLog

- fixed: add tar flags so install works when tar comes from `libarchive`
