### PR TITLE
GH-706 Update location change message

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -741,7 +741,7 @@ activate() {
       log old "${original_node}"
       log new "${active_node}"
       # shellcheck disable=SC2016
-      printf 'To reset the command location hash either start a new shell, or execute PATH="$PATH"\n'
+      printf 'If "node --version" shows the old version then start a new shell, or reset the location hash with:\nhash -r  (for bash, zsh, ash, dash, and ksh)\nrehash   (for csh and tcsh)'
     fi
   fi
 }

--- a/bin/n
+++ b/bin/n
@@ -740,7 +740,6 @@ activate() {
       printf '\nNote: the node command changed location and the old location may be remembered in your current shell.\n'
       log old "${original_node}"
       log new "${active_node}"
-      # shellcheck disable=SC2016
       printf 'If "node --version" shows the old version then start a new shell, or reset the location hash with:\nhash -r  (for bash, zsh, ash, dash, and ksh)\nrehash   (for csh and tcsh)'
     fi
   fi

--- a/bin/n
+++ b/bin/n
@@ -740,7 +740,7 @@ activate() {
       printf '\nNote: the node command changed location and the old location may be remembered in your current shell.\n'
       log old "${original_node}"
       log new "${active_node}"
-      printf 'If "node --version" shows the old version then start a new shell, or reset the location hash with:\nhash -r  (for bash, zsh, ash, dash, and ksh)\nrehash   (for csh and tcsh)'
+      printf 'If "node --version" shows the old version then start a new shell, or reset the location hash with:\nhash -r  (for bash, zsh, ash, dash, and ksh)\nrehash   (for csh and tcsh)\n'
     fi
   fi
 }


### PR DESCRIPTION
# Pull Request

This pull request updates the message printed for a user when installing a new version of Node.js via `n` results in a location change for the binary.

Closes GH-706.

## Problem

One of the recommended solutions does not work in Dash:
```
Note: the node command changed location and the old location may be remembered in your current shell.
         old : /usr/bin/node
         new : /app/.global/bin/node
To reset the command location hash either start a new shell, or execute PATH="$PATH"
```

See GH-706.

## Solution

Update the message to suggest an alternative if using Dash:
```
Note: the node command changed location and the old location may be remembered in your current shell.
         old : /usr/bin/node
         new : /app/.global/bin/node
If "node --version" shows the old version then start a new shell, or reset the location hash with:
hash -r  (for bash, zsh, ash, dash, and ksh)
rehash   (for csh and tcsh)
```


## ChangeLog

Update location change message with recommendation for Dash.
