### PR TITLE
Update China Mirror URL to the New Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Display diagnostics to help resolve problems:
 If you would like to use a different Node.js mirror which has the same layout as the default <https://nodejs.org/dist/>, you can define `N_NODE_MIRROR`.
 The most common example is from users in China who can define:
 
-    export N_NODE_MIRROR=https://npm.taobao.org/mirrors/node
+    export N_NODE_MIRROR=https://npmmirror.com/mirrors/node
 
 If the custom mirror requires authentication you can add the [url-encoded](https://urlencode.org) username and password into the URL. e.g.
 


### PR DESCRIPTION
# Pull Request

https://npm.taobao.org is now redirect to https://npmmirror.com, use the new URL instead.

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request.
-->

## Problem

Switched to the new mirror URL.

<!--
What problem are you solving? Include issue numbers if it has been reported. 
Show the broken output if appropriate.
-->

## Solution

Use the new URL.

<!--
How did you solve the problem? 
Show the fixed output if appropriate.
-->

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
