### PR TITLE
Chore: replace `git.io` in installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Or on macOS with [MacPorts](https://www.macports.org/) you can install the [n po
 
 On Linux and macOS, [n-install](https://github.com/mklement0/n-install) allows installation directly from GitHub; for instance:
 
-    curl -L https://git.io/n-install | bash
+    curl -L https://bit.ly/n-install | bash
 
 n-install sets both `PREFIX` and `N_PREFIX` to `$HOME/n`, installs `n` to `$HOME/n/bin`, modifies the initialization files of supported shells to export `N_PREFIX` and add `$HOME/n/bin` to the `PATH`, and installs the latest LTS Node.js version.
 


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request.
-->

## Problem

All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

## Solution

Update the installation guide with the original URL.

## ChangeLog

- Update the installation guide with the original `n-install` script URL.
