### PR TITLE
Add N_PRESERVE_COREPACK

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,22 +179,24 @@ Or execute a command with `PATH` modified so `node` and `npm` will be from the d
 
 ## Preserving npm
 
-A Node.js install normally includes `npm` as well, but you may wish to preserve an updated `npm` and `npx` leaving them out of the install using `--preserve`:
+A Node.js install normally also includes `npm`,  `npx`, and `corepack`, but you may wish to preserve your current (especially newer) versions using `--preserve`:
 
     $ npm install -g npm@latest
     ...
     $ npm --version
     6.13.7
+    # Node.js 8.17.0 includes (older) npm 6.13.4
     $ n -p 8
        installed : v8.17.0
     $ npm --version
     6.13.7
 
-You can make this the default by setting `N_PRESERVE_NPM` to a non-empty string.
+You can make this the default by setting the environment variable to a non-empty string. There are separate environment variables for `npm` and `corepack`:
 
     export N_PRESERVE_NPM=1
+    export N_PRESERVE_COREPACK=1
 
-You can be explicit to get the desired behaviour whatever the environment variable:
+You can be explicit to get the desired behaviour whatever the environment variables:
 
     n --preserve nightly
     n --no-preserve latest
@@ -276,6 +278,7 @@ In brief:
 - support for [NO_COLOR](https://no-color.org) and [CLICOLOR=0](https://bixense.com/clicolors) for controlling use of ANSI color codes
 - `N_MAX_REMOTE_MATCHES` to change the default `ls-remote` maximum of 20 matching versions
 - `N_PRESERVE_NPM`: See [Preserving npm](#preserving-npm)
+- `N_PRESERVE_COREPACK`: See [Preserving npm](#preserving-npm)
 
 ## How It Works
 

--- a/bin/n
+++ b/bin/n
@@ -695,7 +695,7 @@ activate() {
     clean_copy_folder "$dir/lib/node_modules/npm" "$N_PREFIX/lib/node_modules/npm"
   fi
   # Takes same steps for corepack (experimental in node 16.9.0) as for npm, to avoid version problems.
-  if [[ -e "$dir/lib/node_modules/corepack" ]]; then
+  if [[ -e "$dir/lib/node_modules/corepack" && -z "${N_PRESERVE_COREPACK}" ]]; then
     mkdir -p "$N_PREFIX/lib/node_modules"
     clean_copy_folder "$dir/lib/node_modules/corepack" "$N_PREFIX/lib/node_modules/corepack"
   fi
@@ -707,7 +707,9 @@ activate() {
   # Copy bin items by hand, in case user has installed global npm modules into cache.
   cp -f "$dir/bin/node" "$N_PREFIX/bin"
   [[ -e "$dir/bin/node-waf" ]] && cp -f "$dir/bin/node-waf" "$N_PREFIX/bin" # v0.8.x
-  [[ -e "$dir/bin/corepack" ]] && cp -fR "$dir/bin/corepack" "$N_PREFIX/bin" # from 16.9.0
+  if [[ -z "${N_PRESERVE_COREPACK}" ]]; then
+    [[ -e "$dir/bin/corepack" ]] && cp -fR "$dir/bin/corepack" "$N_PREFIX/bin" # from 16.9.0
+  fi
   if [[ -z "${N_PRESERVE_NPM}" ]]; then
     [[ -e "$dir/bin/npm" ]] && cp -fR "$dir/bin/npm" "$N_PREFIX/bin"
     [[ -e "$dir/bin/npx" ]] && cp -fR "$dir/bin/npx" "$N_PREFIX/bin"
@@ -1422,6 +1424,7 @@ function show_diagnostics() {
   [[ -n "${N_PREFIX}" ]] && echo "PATH: ${PATH}"
   echo "ls-remote max matches: ${N_MAX_REMOTE_MATCHES}"
    [[ -n "${N_PRESERVE_NPM}" ]] && echo "installs preserve npm by default"
+   [[ -n "${N_PRESERVE_COREPACK}" ]] && echo "installs preserve corepack by default"
 
   printf "\nProxy\n"
   # disable "var is referenced but not assigned": https://github.com/koalaman/shellcheck/wiki/SC2154
@@ -1561,8 +1564,8 @@ while [[ $# -ne 0 ]]; do
     -q|--quiet) set_quiet ;;
     -d|--download) DOWNLOAD="true" ;;
     --insecure) set_insecure ;;
-    -p|--preserve) N_PRESERVE_NPM="true" ;;
-    --no-preserve) N_PRESERVE_NPM="" ;;
+    -p|--preserve) N_PRESERVE_NPM="true" N_PRESERVE_COREPACK="true" ;;
+    --no-preserve) N_PRESERVE_NPM="" N_PRESERVE_COREPACK="" ;;
     --use-xz) N_USE_XZ="true" ;;
     --no-use-xz) N_USE_XZ="false" ;;
     --latest) display_remote_versions latest; exit ;;

--- a/test/tests/shared-functions.bash
+++ b/test/tests/shared-functions.bash
@@ -13,6 +13,7 @@ function unset_n_env(){
   unset N_NODE_DOWNLOAD_MIRROR
   unset N_MAX_REMOTE_MATCHES
   unset N_PRESERVE_NPM
+  unset N_PRESERVE_COREPACK
   unset HTTP_USER
   unset HTTP_PASSWORD
   unset GREP_OPTIONS


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request.
-->

## Problem

The `--preserve` and `N_PRESERVE_NPM` features just cover `npm` (and `npx`) but not `corepack`. Users may wish to preserve `corepack` as well.

See: #735

## Solution

It seems reasonable for `--preserve` to preserve `corepack` too.

`corepack` is distributed as an npm package, but it is not part of npm as such. Add a separate environment variable rather than lump it under the existing one.

- have `--preserve` cover `corepack` as well
- add `N_PRESERVE_COREPACK` (rather than include `corepack` in `N_PRESERVE_NPM`)

## ChangeLog

- also preserve `corepack` when use `--preserve`
- add environment variable for `N_PRESERVE_COREPACK`