### PR TITLE
ci(lint): add shell linter - Differential ShellCheck

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -1,0 +1,30 @@
+# Doc: https://github.com/redhat-plumbers-in-action/differential-shellcheck#usage
+---
+
+name: Differential ShellCheck
+on:
+  pull_request:
+    branches: [master, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      pull-requests: write
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@v3
+        with:
+          severity: warning
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

Differential ShellCheck is a GitHub action that performs **differential ShellCheck scans** on shell scripts changed via PR and reports results directly in PR. The beauty of differential scans is that you will get **reports only about newly added defects**. 

Since this repository has many shell scripts, I think you might find some value in having a shell linter. Differential ShellCheck action is able to produce reports in SARIF format. GitHub understands this format and is able to display it nicely as a PR comment, and on the `Files Changed` tab, please see below.

![image](https://user-images.githubusercontent.com/2879818/183250924-b24fdcf1-c10c-4e7a-b4e5-76f25c1e06a0.png)

![image](https://user-images.githubusercontent.com/2879818/183250933-27cd182f-47f5-42fd-a2e6-1789bf5c3fc3.png)

Documentation is available at [@redhat-plumbers-in-action/differential-shellcheck](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme). Let me know If you are missing some feature or setting. I'm always happy to extend functionality.

## Problem

ShellCheck is a powerful linter for shell scripts, but it can be very verbose. It can be issue for projects that didn't use it from the beginning. When introducing ShellCheck later on it requires a lot of work beforehand to disable checks or mask existing "defects". This process could mean for some project risk of introducing regressions when fixing some defects that aren't defects.

## Solution

Using differential scan for ShellCheck allows you to introduce ShellCheck linter faster with minimal work, so you can lint incoming PRs. And later on you can focus on improving existing code if needed.

## ChangeLog

This probably doesn'ŧ have to be mentioned in CHANGELOG.