### PR TITLE
$< make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 PREFIX ?= /usr/local
 
 install: bin/n
-	mkdir -p $(PREFIX)/$(dir $<)
-	cp $< $(PREFIX)/$<
+	mkdir -p $(PREFIX)/$(dir bin/n)
+	cp bin/n $(PREFIX)/bin/n
 
 uninstall:
 	rm -f $(PREFIX)/bin/n

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PREFIX ?= /usr/local
 
 install: bin/n
-	mkdir -p $(PREFIX)/$(dir bin/n)
+	mkdir -p $(PREFIX)/bin
 	cp bin/n $(PREFIX)/bin/n
 
 uninstall:


### PR DESCRIPTION
Apparently $< is not working propertly on FreeBSD.

```
[kandy@ ~/a/n]$ make install
mkdir -p /usr/local/
cp  /usr/local/
usage: cp [-R [-H | -L | -P]] [-f | -i | -n] [-alpsvx] source_file target_file
       cp [-R [-H | -L | -P]] [-f | -i | -n] [-alpsvx] source_file ... target_directory
*** Error code 64

Stop.
make: stopped in /usr/home/kandy/a/n
```

Changing the Makefile from $< to bin/n works.

```
[kandy@ ~/a/n]$ freebsd-version
13.1-RELEASE
```
