### PR TITLE
Add quotes to work with PREFIX containing spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 PREFIX ?= /usr/local
 
 install: bin/n
-	mkdir -p $(PREFIX)/bin
-	cp bin/n $(PREFIX)/bin/n
+	mkdir -p "$(PREFIX)/bin"
+	cp bin/n "$(PREFIX)/bin/n"
 
 uninstall:
-	rm -f $(PREFIX)/bin/n
+	rm -f "$(PREFIX)/bin/n"
 
 .PHONY: install uninstall


### PR DESCRIPTION
# Pull Request

## Problem

Noticed from code inspection that spaces in the PREFIX would break the `Makefile` actions

## Solution

Add quotes around the paths using `$PREFIX`

## ChangeLog

- Fix: support spaces in `PREFIX` used with `Makefile`
