### PR TITLE
Display node version architecture when on interactive mode

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -505,10 +505,11 @@ display_versions_with_selected() {
   local selected="$1"
   echo
   for version in $(display_versions_paths); do
+    current_version="$version - $(file $CACHE_DIR/$version/bin/node -b | awk '{print $4}')"
     if test "$version" = "$selected"; then
-      printf "  ${SGR_CYAN}ο${SGR_RESET} %s\n" "$version"
+      printf "  ${SGR_CYAN}ο${SGR_RESET} %s\n" "$current_version"
     else
-      printf "    ${SGR_FAINT}%s${SGR_RESET}\n" "$version"
+      printf "    ${SGR_FAINT}%s${SGR_RESET}\n" "$current_version"
     fi
   done
   echo


### PR DESCRIPTION
# Pull Request

Display node versions architecture when on interactive mode

## Problem

Sometimes npm libs can be compatible only with arm64 or x64

## Solution

```
n
```
![Capture d’écran 2022-12-20 à 11 22 36](https://user-images.githubusercontent.com/32040951/208644101-7cabde7b-6dbf-4cc1-9ab7-8197e1a64792.png)

