### PR TITLE
One step install of Node.js for bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,10 @@ To avoid requiring `sudo` for `n` and `npm` global installs, it is suggested you
 
 -----
 
-If `npm` is not yet available, one way to bootstrap an install:
+If `npm` is not yet available, one way to bootstrap an install is to download and run `n` directly. To install the `lts` version of Node.js:
 
-    curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o n
-    bash n lts
-    # Now node and npm are available
+    curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s lts
+    # If you want n installed, you can use npm now.
     npm install -g n
 
 Alternatively, you can clone this repo and


### PR DESCRIPTION
# Pull Request

## Problem

The previous bootstrap steps included downloading the `n` script to a file. This was not needed for the suggested steps, and might hit permission errors depending on current folder.

See #748.

## Solution

Just pipe `n` into bash. This is a typical install pattern used by other products. e.g.

```console
# https://brew.sh
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

# https://github.com/mklement0/n-install
curl -L https://bit.ly/n-install | bash

# https://github.com/nvm-sh/nvm
curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
```

 In our case it is actually the `n` script rather than an installer as such, so the comments clarify what is happening and include mention of then installing `n` if desired.
