### PR TITLE
Add fedora as a second Linux for main tests

### DIFF
--- a/test/bin/run-all-tests
+++ b/test/bin/run-all-tests
@@ -2,7 +2,7 @@
 BIN_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # We want to cover curl and wget especially, gz and xz and variety of OS a bonus.
-services=( ubuntu-curl ubuntu-wget )
+services=( fedora-curl ubuntu-wget )
 
 cd "$(dirname "${BIN_DIRECTORY}")" || exit 2
 for service in "${services[@]}" ; do

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -14,3 +14,10 @@ services:
     build:
       context: dockerfiles
       dockerfile: Dockerfile-ubuntu-wget
+  fedora-curl:
+    extends:
+      file: ./docker-base.yml
+      service: testbed
+    build:
+      context: dockerfiles
+      dockerfile: Dockerfile-fedora-curl

--- a/test/dockerfiles/Dockerfile-fedora-curl
+++ b/test/dockerfiles/Dockerfile-fedora-curl
@@ -1,0 +1,3 @@
+FROM fedora:latest
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
# Pull Request

## Problem

Only using one flavour of Linux in tests.

## Solution

Add Fedora to use for curl (installed by default). Has X86 and ARM builds.
