### PR TITLE
Add npm check to doctor

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -1484,6 +1484,20 @@ function show_diagnostics() {
     fi
   fi
 
+  # Check npm too. Simpler check than for PATH and node, more like the runtime logging for active/installed node.
+  if [[ -z "${N_PRESERVE_NPM}" ]]; then
+    printf "\nChecking npm install destination\n"
+    local installed_npm="${N_PREFIX}/bin/npm"
+    local active_npm="$(command -v npm)"
+    if [[ -e "${active_npm}" && -e "${installed_npm}" && "${active_npm}" != "${installed_npm}" ]]; then
+      echo_red "There is an active version of npm shadowing the version installed by n. Check order of entries in PATH."
+      log "installed" "${installed_npm}"
+      log "active" "${active_npm}"
+    else
+      printf "good\n"
+    fi
+  fi
+
   printf "\nChecking permissions for cache folder...\n"
   # Most likely problem is ownership rather than than permissions as such.
   local cache_root="${N_PREFIX}/n"

--- a/bin/n
+++ b/bin/n
@@ -1486,7 +1486,7 @@ function show_diagnostics() {
 
   # Check npm too. Simpler check than for PATH and node, more like the runtime logging for active/installed node.
   if [[ -z "${N_PRESERVE_NPM}" ]]; then
-    printf "\nChecking npm install destination\n"
+    printf "\nChecking npm install destination...\n"
     local installed_npm="${N_PREFIX}/bin/npm"
     local active_npm="$(command -v npm)"
     if [[ -e "${active_npm}" && -e "${installed_npm}" && "${active_npm}" != "${installed_npm}" ]]; then


### PR DESCRIPTION
## Problem

People may have installed npm separately before trying `n` for managing Node.js (node + npm) and shadow the version installed by `n`.

See: #762

## Solution

Add a check to `n doctor`. This could be detected at install time, but just adding to `n doctor` for now.

Generates warning like:
```
Checking npm install destination...
There is an active version of npm shadowing the version installed by n. Check what is in PATH (unless this is expected).
   installed : /usr/local/bin/npm
      active : /Users/john/my_npm/bin/npm
```

## ChangeLog

- check for possible problem with multiple `npm` locations when running `n doctor`
