### PR TITLE
Remove use of curl --compressed due to a bug in 8.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- markdownlint-disable MD024 -->
 
-## [Unreleased] (date goes here)
+## [9.2.2] (2024-04-21)
+
+### Fixed
+
+- avoid problems with `curl` 8.7.1 and `--compressed` by removing option until fixed
 
 ## [9.2.1] (2024-02-25)
 
@@ -500,6 +504,7 @@ Only minor functional changes, but technically could break scripts relying on sp
 <!-- reference links for releases -->
 
 [Unreleased]: https://github.com/tj/n/compare/master...develop
+[9.2.2]: https://github.com/tj/n/compare/v9.2.1...v9.2.2
 [9.2.1]: https://github.com/tj/n/compare/v9.2.0...v9.2.1
 [9.2.0]: https://github.com/tj/n/compare/v9.1.0...v9.2.0
 [9.1.0]: https://github.com/tj/n/compare/v9.0.1...v9.1.0

--- a/bin/n
+++ b/bin/n
@@ -61,7 +61,7 @@ function n_grep() {
 # Setup and state
 #
 
-VERSION="v9.2.2-0"
+VERSION="v9.2.2"
 
 N_PREFIX="${N_PREFIX-/usr/local}"
 N_PREFIX=${N_PREFIX%/}
@@ -853,7 +853,7 @@ function do_get() {
 function do_get_index() {
   if command -v curl &> /dev/null; then
     # --silent to suppress progress et al
-    curl --silent --compressed "${CURL_OPTIONS[@]}" "$@"
+    curl --silent "${CURL_OPTIONS[@]}" "$@"
   elif command -v wget &> /dev/null; then
     wget "${WGET_OPTIONS[@]}" "$@"
   else


### PR DESCRIPTION
Work-around problems with curl 8.7.1 (see #799) by removing used of `--compressed` for now. Homebrew has Curl 8.7.1 so it isn't just in unstable Linux distributions. Will be about a month before the upstream fix lands.