### PR TITLE
Docs for switching node directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ As a result, both `n` itself and all Node.js versions it manages are hosted insi
 
 ### Multiple Copies of Node.js
 
-If you end up with multiple copies of `node` in your `PATH`, see [docs](./docs/changing-node-location.md) for a detailed walk-through of how to tidy up. This can easily happen if you already had Node.js installed in some other way before using `n`.
+Changing  from a previous Node.js installed to a different location may involve a few extra steps. See docs for [changing node location]((./docs/changing-node-location.md)) for a walk-through example of switching from using Homebrew to using `n` to manage Node.js.
 
-The big clue you have this problem is if after installing node you see the progress telling you the "installed" and "active" locations are different, like:
+You have a problem with multiple versions if after installing node you see the "installed" and "active" locations are different:
 ```console
 % n lts
      copying : node/20.12.2

--- a/README.md
+++ b/README.md
@@ -90,7 +90,15 @@ As a result, both `n` itself and all Node.js versions it manages are hosted insi
 
 ### Multiple Copies of Node.js
 
-If you end up with multiple copies of `node` in your `PATH` so the freshly installed version is not active, see [docs](./docs/changing-node-location.md) for a detailed walk-through of how to tidy up. This can easily happen if you already had Node.js installed in some other way before using `n`.
+If you end up with multiple copies of `node` in your `PATH`, see [docs](./docs/changing-node-location.md) for a detailed walk-through of how to tidy up. This can easily happen if you already had Node.js installed in some other way before using `n`.
+
+The big clue you have this problem is if after installing node you see the progress telling you the "installed" and "active" locations are different, like:
+```console
+% n lts
+     copying : node/20.12.2
+   installed : v20.12.2 to /usr/local/bin/node
+      active : v21.7.3 at /opt/homebrew/bin/node
+```
 
 ## Installing Node.js Versions
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Node.js version management: no subshells, no profile setup, no convoluted API, j
     - [Supported Platforms](#supported-platforms)
     - [Installation](#installation)
         - [Third Party Installers](#third-party-installers)
+        - [Multiple Copies of Node.js](#multiple-copies-of-nodejs)
     - [Installing Node.js Versions](#installing-nodejs-versions)
     - [Specifying Node.js Versions](#specifying-nodejs-versions)
     - [Removing Versions](#removing-versions)
@@ -86,6 +87,10 @@ On Linux and macOS, [n-install](https://github.com/mklement0/n-install) allows i
 n-install sets both `PREFIX` and `N_PREFIX` to `$HOME/n`, installs `n` to `$HOME/n/bin`, modifies the initialization files of supported shells to export `N_PREFIX` and add `$HOME/n/bin` to the `PATH`, and installs the latest LTS Node.js version.
 
 As a result, both `n` itself and all Node.js versions it manages are hosted inside a single, optionally configurable directory, which you can later remove with the included `n-uninstall` script. `n-update` updates `n` itself to the latest version. See the [n-install repo](https://github.com/mklement0/n-install) for more details.
+
+### Multiple Copies of Node.js
+
+If you end up with multiple copies of `node` in your `PATH`, see [docs](./docs/changing-node-location.md) for a detailed walk-through of how to tidy up. This can easily happen is you already had Node.js installed in some other way before using `n`.
 
 ## Installing Node.js Versions
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ As a result, both `n` itself and all Node.js versions it manages are hosted insi
 
 ### Multiple Copies of Node.js
 
-If you end up with multiple copies of `node` in your `PATH`, see [docs](./docs/changing-node-location.md) for a detailed walk-through of how to tidy up. This can easily happen is you already had Node.js installed in some other way before using `n`.
+If you end up with multiple copies of `node` in your `PATH` so the freshly installed version is not active, see [docs](./docs/changing-node-location.md) for a detailed walk-through of how to tidy up. This can easily happen is you already had Node.js installed in some other way before using `n`.
 
 ## Installing Node.js Versions
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ As a result, both `n` itself and all Node.js versions it manages are hosted insi
 
 ### Multiple Copies of Node.js
 
-If you end up with multiple copies of `node` in your `PATH` so the freshly installed version is not active, see [docs](./docs/changing-node-location.md) for a detailed walk-through of how to tidy up. This can easily happen is you already had Node.js installed in some other way before using `n`.
+If you end up with multiple copies of `node` in your `PATH` so the freshly installed version is not active, see [docs](./docs/changing-node-location.md) for a detailed walk-through of how to tidy up. This can easily happen if you already had Node.js installed in some other way before using `n`.
 
 ## Installing Node.js Versions
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Node.js version management: no subshells, no profile setup, no convoluted API, j
     - [Supported Platforms](#supported-platforms)
     - [Installation](#installation)
         - [Third Party Installers](#third-party-installers)
-        - [Multiple Copies of Node.js](#multiple-copies-of-nodejs)
+        - [Replacing a previous node install](#replacing-a-previous-node-install)
     - [Installing Node.js Versions](#installing-nodejs-versions)
     - [Specifying Node.js Versions](#specifying-nodejs-versions)
     - [Removing Versions](#removing-versions)
@@ -88,9 +88,9 @@ n-install sets both `PREFIX` and `N_PREFIX` to `$HOME/n`, installs `n` to `$HOME
 
 As a result, both `n` itself and all Node.js versions it manages are hosted inside a single, optionally configurable directory, which you can later remove with the included `n-uninstall` script. `n-update` updates `n` itself to the latest version. See the [n-install repo](https://github.com/mklement0/n-install) for more details.
 
-### Multiple Copies of Node.js
+### Replacing a previous node install
 
-Changing  from a previous Node.js installed to a different location may involve a few extra steps. See docs for [changing node location]((./docs/changing-node-location.md)) for a walk-through example of switching from using Homebrew to using `n` to manage Node.js.
+Changing from a previous Node.js installed to a different location may involve a few extra steps. See docs for [changing node location]((./docs/changing-node-location.md)) for a walk-through example of switching from using Homebrew to using `n` to manage Node.js.
 
 You have a problem with multiple versions if after installing node you see the "installed" and "active" locations are different:
 ```console

--- a/docs/changing-node-location.md
+++ b/docs/changing-node-location.md
@@ -4,10 +4,9 @@ If you already have Node.js installed to a different root than `n` uses, you can
 - uninstall from the old directory and reinstall to the new directory
 - put the `bin` directory that `n` uses early in the `PATH` environment variable, so the `n` installed node is found first
 
-
 The simplest setup to understand is the first one. Just have one version of `node` installed.
 
-Let's walk-through the process of switching over using Homebrew as an example. Let's start off with Node.js installed, `npm` updated, and an example global npm package. 
+Let's walk-through the process of switching over from using Homebrew as an example. Let's start off with Node.js installed, `npm` updated, and an example global npm package. 
 
 ```console
 % brew install node

--- a/docs/changing-node-location.md
+++ b/docs/changing-node-location.md
@@ -1,12 +1,16 @@
 # Switching To `n` Managed Node.js
 
 If you already have Node.js installed to a different root than `n` uses, you can easily end up with multiple copies of node (and npm, and npx, and globally installed packages!). Some common situations are you already had Node.js installed  using your Linux package manager, or using another node version manager, or using say Homebrew. The two main ways you might resolve this are:
+
 - uninstall from the old directory and reinstall to the new directory
 - put the `bin` directory that `n` uses early in the `PATH` environment variable, so the `n` installed node is found first
 
 The simplest setup to understand is the first one. Just have one version of `node` installed.
 
-Let's walk-through the process of switching over from using Homebrew as an example. Let's start off with Node.js installed, `npm` updated, and an example global npm package. 
+Let's walk-through the process of switching over from using Homebrew as an example. Let's start off with Node.js installed, `npm` updated, and an example global npm package. The key point is there are two install prefixes involved:
+
+- old: `/opt/homebrew`
+- new: `/usr/local`
 
 ```console
 % brew install node
@@ -24,9 +28,13 @@ Let's walk-through the process of switching over from using Homebrew as an examp
 /opt/homebrew/Cellar/node/21.7.3/share/man/man1/node.1
 % command -v node
 /opt/homebrew/bin/node
+% command -v npm 
+/opt/homebrew/bin/npm
+% npm prefix --global
+/opt/homebrew
 ```
 
-Before we start, list the global npm packages in the "old" location. We will refer back to this list. (Suggest doing this early in case you break things!)
+Before we start transferring, list the global npm packages in the "old" location. We will refer back to this list.
 
 ```console
 % npm list --global
@@ -35,7 +43,7 @@ Before we start, list the global npm packages in the "old" location. We will ref
 └── npm@10.5.0
 ```
 
-We could clean out the old location first, but let's install `n` and another copy of node to see what happens. We end up with two versions of node, and the active one is still the Homebrew managed version.
+We could clean out the old location first, but let's install `n` and another copy of node and see what that looks like. We end up with two versions of node, and the active one is still the Homebrew managed version.
 
 ```console
 % brew install n
@@ -84,7 +92,7 @@ npm uninstall --global npm
 brew uninstall node
 ```
 
-Check the only versions left of the Node.js binaries are the versions installed by `n`:
+Check the active binaries are now the ones installed by `n`:
 ```console
 % command -v node
 /usr/local/bin/node
@@ -96,6 +104,8 @@ Check the only versions left of the Node.js binaries are the versions installed 
 
 And lastly, reinstall the global npm packages you started with:
 ```
+% npm prefix --global
+/usr/local
 % npm install --global npm@latest
 % npm install --global @shadowspawn/forest-arborist
 % npm list -g

--- a/docs/changing-node-location.md
+++ b/docs/changing-node-location.md
@@ -1,0 +1,106 @@
+# Switching to `n` managed node
+
+If you already have Node.js installed to a different root than `n` uses, you can easily end up with multiple copies of node (and npm, and npx, and globally installed packages!). Some common situations are you already had Node.js installed  using your Linux package manager, or using another node version manager, or using say Homebrew. The two main ways you might resolve this are:
+- uninstall from the old directory and reinstall to the new directory
+- put the `bin` directory that `n` uses early in the `PATH` environment variable, so the `n` installed node is found first
+
+
+The simplest setup to understand is the first one. Just have one version of `node` installed.
+
+Let's walk-through the process of switching over using Homebrew as an example. Let's start off with Node.js installed, `npm` updated, and an example global npm package. 
+
+```console
+% brew install node
+% npm install --global npm@latest
+% npm install --global @shadowspawn/forest-arborist
+% brew list node
+/opt/homebrew/Cellar/node/21.7.3/bin/node
+/opt/homebrew/Cellar/node/21.7.3/bin/npm
+/opt/homebrew/Cellar/node/21.7.3/bin/npx
+/opt/homebrew/Cellar/node/21.7.3/etc/bash_completion.d/npm
+/opt/homebrew/Cellar/node/21.7.3/include/node/ (107 files)
+/opt/homebrew/Cellar/node/21.7.3/libexec/bin/ (2 files)
+/opt/homebrew/Cellar/node/21.7.3/libexec/lib/ (2012 files)
+/opt/homebrew/Cellar/node/21.7.3/share/doc/ (2 files)
+/opt/homebrew/Cellar/node/21.7.3/share/man/man1/node.1
+% command -v node
+/opt/homebrew/bin/node
+```
+
+Before we start, list the global npm packages in the "old" location. We will refer back to this list. (Suggest doing this early in case you break things!)
+
+```console
+% npm list --global
+/opt/homebrew/lib
+├── @shadowspawn/forest-arborist@12.0.0
+└── npm@10.5.0
+```
+
+We could clean out the old location first, but let's install `n` and another copy of node to see what happens. We end up with two versions of node, and the active one is still the Homebrew managed version.
+
+```console
+% brew install n
+% n lts
+  installing : node-v20.12.2
+       mkdir : /usr/local/n/versions/node/20.12.2
+       fetch : https://nodejs.org/dist/v20.12.2/node-v20.12.2-darwin-arm64.tar.xz
+     copying : node/20.12.2
+   installed : v20.12.2 to /usr/local/bin/node
+      active : v21.7.3 at /opt/homebrew/bin/node
+% command -v node
+/opt/homebrew/bin/node
+% which -a node
+/opt/homebrew/bin/node
+/usr/local/bin/node
+% command -v npm
+/opt/homebrew/bin/npm
+% command -v npx
+/opt/homebrew/bin/npx
+% n doctor
+<...>
+
+CHECKS
+
+Checking n install destination is in PATH...
+good
+
+Checking n install destination priority in PATH...
+⚠️ There is a version of node installed which will be found in PATH before the n installed version.
+
+Checking npm install destination...
+⚠️ There is an active version of npm shadowing the version installed by n. Check order of entries in PATH.
+   installed : /usr/local/bin/npm
+      active : /opt/homebrew/bin/npm
+
+<...>
+```
+
+Now let's switch over. Delete everything from the old location. Delete all the global npm packages _except_ npm itself, then delete npm, then delete node.
+
+```console
+npm uninstall --global @shadowspawn/forest-arborist
+
+npm uninstall --global npm
+
+brew uninstall node
+```
+
+Check the only versions left of the Node.js binaries are the versions installed by `n`:
+```console
+% command -v node
+/usr/local/bin/node
+% command -v npm 
+/usr/local/bin/npm
+% command -v npx
+/usr/local/bin/npx
+```
+
+And lastly, reinstall the global npm packages you started with:
+```
+% npm install --global npm@latest
+% npm install --global @shadowspawn/forest-arborist
+% npm list -g
+/usr/local/lib
+├── @shadowspawn/forest-arborist@12.0.0
+└── npm@10.5.0
+```

--- a/docs/changing-node-location.md
+++ b/docs/changing-node-location.md
@@ -1,4 +1,4 @@
-# Switching to `n` managed node
+# Switching To `n` Managed Node.js
 
 If you already have Node.js installed to a different root than `n` uses, you can easily end up with multiple copies of node (and npm, and npx, and globally installed packages!). Some common situations are you already had Node.js installed  using your Linux package manager, or using another node version manager, or using say Homebrew. The two main ways you might resolve this are:
 - uninstall from the old directory and reinstall to the new directory


### PR DESCRIPTION
# Pull Request

## Problem

Multiple people ask about having two versions of `node` installed. It is a bit subtle to do the full switch-over with potentially node, and npm, and npx, and globally installed packages. I often skip over the details and just suggest to "delete the other one".

Switching from Homebrew in particular has been popular recently. See: #768

## Solution

Add separate document with a walk-through of switching from Homebrew managed Node.js to `n` managed Node.js. 