### PR TITLE
If `jq` is installed, use it to get values from package.json

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -1084,9 +1084,14 @@ function get_package_engine_version() {
   g_target_node=
   local filepath="$1"
   verbose_log "found" "${filepath}"
-  command -v node &> /dev/null || abort "an active version of node is required to read 'engines' from package.json"
   local range
-  range="$(node -e "package = require('${filepath}'); if (package && package.engines && package.engines.node) console.log(package.engines.node)")"
+  if command -v jq &> /dev/null; then
+    range="$(jq -r '.engines.node // ""' < "${filepath}")"
+  elif command -v node &> /dev/null; then
+    range="$(node -e "package = require('${filepath}'); if (package && package.engines && package.engines.node) console.log(package.engines.node)")"
+  else
+    abort "either jq or an active version of node is required to read 'engines' from package.json"
+  fi
   verbose_log "read" "${range}"
   [[ -n "${range}" ]] || return 2
   if [[ "*" == "${range}" ]]; then
@@ -1472,6 +1477,13 @@ function show_diagnostics() {
     command -v wget && wget --version
   else
     echo_red "Neither curl nor wget found. Need one of them for downloads."
+  fi
+
+  printf "\njq\n"
+  if command -v jq &> /dev/null; then
+    command -v jq && jq --version
+  else
+    echo "jq not found, can be used to get package.json values faster than node"
   fi
 
   printf "\nuname\n"


### PR DESCRIPTION
# Pull Request

`jq` is a popular choice for being installed, especially on CI machines, and using it is much faster than running node.

## Problem

Using `node` can be problematic if it's not installed yet, and it also has a much higher overhead (= time) to start.  Doesn't matter for an automated CI case, but in interactive use the potential doubling of running `node` is noticeable.

## Solution

Use `jq` if it's installed.  This is very straightforward use of `jq`, so prefer that over `node` if it is installed.

## ChangeLog

* Use `jq` to read values from `package.json` if it is installed.

Closes #807.
