### PR TITLE
Fast track exact auto

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -1205,6 +1205,16 @@ function get_auto_version() {
 function get_latest_resolved_version() {
   g_target_node=
   local version=${1}
+
+  # Transform some labels before processing further to allow fast-track for exact numeric versions.
+  if [[ "${version}" = "auto" ]]; then
+    get_auto_version || return 2
+    version="${g_target_node}"
+  elif [[ "${version}" = "engine" ]]; then
+    get_engine_version || return 2
+    version="${g_target_node}"
+  fi
+
   simple_version=${version#node/} # Only place supporting node/ [sic]
   if is_exact_numeric_version "${simple_version}"; then
     # Just numbers, already resolved, no need to lookup first.
@@ -1259,11 +1269,9 @@ function display_local_versions() {
     version="$(display_latest_node_support_alias "${version}")"
     match_count=1
   elif [[ "${version}" = "auto" ]]; then
-    # suppress stdout logging so lsr layout same as usual for scripting
     get_auto_version || return 2
     version="${g_target_node}"
   elif [[ "${version}" = "engine" ]]; then
-    # suppress stdout logging so lsr layout same as usual for scripting
     get_engine_version || return 2
     version="${g_target_node}"
   fi
@@ -1310,11 +1318,9 @@ function display_remote_versions() {
     version="$(display_latest_node_support_alias "${version}")"
     match_count=1
   elif [[ "${version}" = "auto" ]]; then
-    # suppress stdout logging so lsr layout same as usual for scripting
     get_auto_version || return 2
     version="${g_target_node}"
   elif [[ "${version}" = "engine" ]]; then
-    # suppress stdout logging so lsr layout same as usual for scripting
     get_engine_version || return 2
     version="${g_target_node}"
   fi

--- a/test/bin/run-all-tests
+++ b/test/bin/run-all-tests
@@ -7,7 +7,7 @@ services=( fedora-curl ubuntu-wget )
 cd "$(dirname "${BIN_DIRECTORY}")" || exit 2
 for service in "${services[@]}" ; do
   echo "${service}"
-  docker-compose run --rm "${service}" "bats" "/mnt/test/tests"
+  docker compose run --rm "${service}" "bats" "/mnt/test/tests"
   echo ""
 done
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   ubuntu-curl:
     extends:

--- a/test/tests.md
+++ b/test/tests.md
@@ -20,17 +20,17 @@ Run all the tests on a single system:
 
     cd test
     npx bats tests
-    docker-compose run ubuntu-curl bats /mnt/test/tests
+    docker compose run ubuntu-curl bats /mnt/test/tests
 
 Run single test on a single system::
 
     cd test
     npx bats tests/install-contents.bats
-    docker-compose run ubuntu-curl bats /mnt/test/tests/install-contents.bats
+    docker compose run ubuntu-curl bats /mnt/test/tests/install-contents.bats
 
 ## Docker Tips
 
-Using `docker-compose` in addition to `docker` for convenient mounting of `n` script and the tests into the container. Changes to the tests or to `n` itself are reflected immediately without needing to rebuild the containers.
+Using `docker compose` in addition to `docker` for convenient mounting of `n` script and the tests into the container. Changes to the tests or to `n` itself are reflected immediately without needing to rebuild the containers.
 
 `bats` is being mounted directly out of `node_modules` into the container as a manual install based on its own install script. This is a bit of a hack, but avoids needing to install `git` or `npm` for a full remote install of `bats`, and means everything on the same version of `bats`.
 
@@ -38,7 +38,7 @@ The containers each have:
 
 * either curl or wget (or both) installed
 
-Using `docker-compose` to run the container adds:
+Using `docker compose` to run the container adds:
 
 * specified `n` script mounted to `/usr/local/bin/n`
 * `test/tests` mounted to `/mnt/test/tests`
@@ -48,7 +48,7 @@ Using `docker-compose` to run the container adds:
 So for example:
 
     cd test
-    docker-compose run ubuntu-curl
+    docker compose run ubuntu-curl
       # in container
       n --version
       bats /mnt/test/tests


### PR DESCRIPTION
# Pull Request

## Problem

Using `auto` and `engine` always do a network lookup even when the target version is a fully specified numeric version. This is an unnecessary extra step for `which` and `run` and `exec`.

See #812

## Solution

Add another pre-process for `auto` and `engine` to allow the fast-track for numeric versions.

## ChangeLog

Changed: avoid a network lookup if `auto` or `engine` have a fully specified numeric version.