### PR TITLE
mask download url when there is a password

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -793,7 +793,8 @@ install() {
   log installing "${g_mirror_folder_name}-v$version"
 
   local url="$(tarball_url "$version")"
-  is_ok "${url}" || abort "download preflight failed for '$version' (${url})"
+  local masked_url=$(echo "$url" | sed -r 's/(https?:\/\/[^:]+):([^@]+)@/\1:*****@/')
+  is_ok "${url}" || abort "download preflight failed for '$version' (${masked_url})"
 
   log mkdir "$dir"
   mkdir -p "$dir" || abort "sudo required (or change ownership, or define N_PREFIX)"
@@ -801,7 +802,7 @@ install() {
 
   cd "${dir}" || abort "Failed to cd to ${dir}"
 
-  log fetch "$url"
+  log fetch "${masked_url}"
   do_get "${url}" | tar "$tarflag" --strip-components=1 --no-same-owner -f -
   pipe_results=( "${PIPESTATUS[@]}" )
   if [[ "${pipe_results[0]}" -ne 0 ]]; then

--- a/bin/n
+++ b/bin/n
@@ -1498,7 +1498,7 @@ function show_diagnostics() {
   printf "\n\nSETTINGS\n"
 
   printf "\nn\n"
-  echo "node mirror: $(display_masked_url ${N_NODE_MIRROR})"
+  echo "node mirror: $(display_masked_url "${N_NODE_MIRROR}")"
   echo "node downloads mirror: $(display_masked_url "${N_NODE_DOWNLOAD_MIRROR}")"
   echo "install destination: ${N_PREFIX}"
   [[ -n "${N_PREFIX}" ]] && echo "PATH: ${PATH}"

--- a/bin/n
+++ b/bin/n
@@ -1245,7 +1245,7 @@ display_remote_index() {
   do_get_index "${index_url}" | tail -n +2 | cut -f 1,3,10
   if [[ "${PIPESTATUS[0]}" -ne 0 ]]; then
     # Reminder: abort will only exit subshell, but consistent error display
-    abort "failed to download version index $(display_masked_url "${index_url}")"
+    abort "failed to download version index ($(display_masked_url "${index_url}"))"
   fi
 }
 

--- a/bin/n
+++ b/bin/n
@@ -797,7 +797,7 @@ install() {
   log installing "${g_mirror_folder_name}-v$version"
 
   local url="$(tarball_url "$version")"
-  is_ok "${url}" || abort "download preflight failed for '$version' '$(display_masked_url ${url})'"
+  is_ok "${url}" || abort "download preflight failed for '$version' '$(display_masked_url "${url})"'"
 
   log mkdir "$dir"
   mkdir -p "$dir" || abort "sudo required (or change ownership, or define N_PREFIX)"

--- a/bin/n
+++ b/bin/n
@@ -1245,7 +1245,7 @@ display_remote_index() {
   do_get_index "${index_url}" | tail -n +2 | cut -f 1,3,10
   if [[ "${PIPESTATUS[0]}" -ne 0 ]]; then
     # Reminder: abort will only exit subshell, but consistent error display
-    abort "failed to download version index $(display_masked_url ${index_url})"
+    abort "failed to download version index $(display_masked_url "${index_url}")"
   fi
 }
 

--- a/bin/n
+++ b/bin/n
@@ -197,7 +197,7 @@ display_major_version() {
     echo "${version}"
 }
 
-masked_url() {
+display_masked_url() {
   echo "$1" | sed -r 's/(https?:\/\/[^:]+):([^@]+)@/\1:****@/'
 }
 
@@ -797,7 +797,7 @@ install() {
   log installing "${g_mirror_folder_name}-v$version"
 
   local url="$(tarball_url "$version")"
-  is_ok "${url}" || abort "download preflight failed for '$version' '$(masked_url ${url})'"
+  is_ok "${url}" || abort "download preflight failed for '$version' '$(display_masked_url ${url})'"
 
   log mkdir "$dir"
   mkdir -p "$dir" || abort "sudo required (or change ownership, or define N_PREFIX)"
@@ -805,7 +805,7 @@ install() {
 
   cd "${dir}" || abort "Failed to cd to ${dir}"
 
-  log fetch "$(masked_url ${url})"
+  log fetch "$(display_masked_url ${url})"
   do_get "${url}" | tar "$tarflag" --strip-components=1 --no-same-owner -f -
   pipe_results=( "${PIPESTATUS[@]}" )
   if [[ "${pipe_results[0]}" -ne 0 ]]; then
@@ -1245,7 +1245,7 @@ display_remote_index() {
   do_get_index "${index_url}" | tail -n +2 | cut -f 1,3,10
   if [[ "${PIPESTATUS[0]}" -ne 0 ]]; then
     # Reminder: abort will only exit subshell, but consistent error display
-    abort "failed to download version index $(masked_url ${index_url})"
+    abort "failed to download version index $(display_masked_url ${index_url})"
   fi
 }
 
@@ -1498,8 +1498,8 @@ function show_diagnostics() {
   printf "\n\nSETTINGS\n"
 
   printf "\nn\n"
-  echo "node mirror: $(masked_url ${N_NODE_MIRROR})"
-  echo "node downloads mirror: $(masked_url ${N_NODE_DOWNLOAD_MIRROR})"
+  echo "node mirror: $(display_masked_url ${N_NODE_MIRROR})"
+  echo "node downloads mirror: $(display_masked_url "${N_NODE_DOWNLOAD_MIRROR}")"
   echo "install destination: ${N_PREFIX}"
   [[ -n "${N_PREFIX}" ]] && echo "PATH: ${PATH}"
   echo "ls-remote max matches: ${N_MAX_REMOTE_MATCHES}"

--- a/bin/n
+++ b/bin/n
@@ -197,6 +197,10 @@ display_major_version() {
     echo "${version}"
 }
 
+masked_url() {
+  echo "$1" | sed -r 's/(https?:\/\/[^:]+):([^@]+)@/\1:****@/'
+}
+
 #
 # Synopsis: update_mirror_settings_for_version version
 # e.g. <nightly/latest> means using download mirror and folder is nightly
@@ -793,8 +797,7 @@ install() {
   log installing "${g_mirror_folder_name}-v$version"
 
   local url="$(tarball_url "$version")"
-  local masked_url=$(echo "$url" | sed -r 's/(https?:\/\/[^:]+):([^@]+)@/\1:*****@/')
-  is_ok "${url}" || abort "download preflight failed for '$version' (${masked_url})"
+  is_ok "${url}" || abort "download preflight failed for '$version' '$(masked_url ${url})'"
 
   log mkdir "$dir"
   mkdir -p "$dir" || abort "sudo required (or change ownership, or define N_PREFIX)"
@@ -802,7 +805,7 @@ install() {
 
   cd "${dir}" || abort "Failed to cd to ${dir}"
 
-  log fetch "${masked_url}"
+  log fetch "$(masked_url ${url})"
   do_get "${url}" | tar "$tarflag" --strip-components=1 --no-same-owner -f -
   pipe_results=( "${PIPESTATUS[@]}" )
   if [[ "${pipe_results[0]}" -ne 0 ]]; then
@@ -1242,7 +1245,7 @@ display_remote_index() {
   do_get_index "${index_url}" | tail -n +2 | cut -f 1,3,10
   if [[ "${PIPESTATUS[0]}" -ne 0 ]]; then
     # Reminder: abort will only exit subshell, but consistent error display
-    abort "failed to download version index (${index_url})"
+    abort "failed to download version index $(masked_url ${index_url})"
   fi
 }
 
@@ -1496,7 +1499,7 @@ function show_diagnostics() {
 
   printf "\nn\n"
   echo "node mirror: ${N_NODE_MIRROR}"
-  echo "node downloads mirror: ${N_NODE_DOWNLOAD_MIRROR}"
+  echo "node downloads mirror: $(masked_url "${N_NODE_DOWNLOAD_MIRROR}")"
   echo "install destination: ${N_PREFIX}"
   [[ -n "${N_PREFIX}" ]] && echo "PATH: ${PATH}"
   echo "ls-remote max matches: ${N_MAX_REMOTE_MATCHES}"

--- a/bin/n
+++ b/bin/n
@@ -805,7 +805,7 @@ install() {
 
   cd "${dir}" || abort "Failed to cd to ${dir}"
 
-  log fetch "$(display_masked_url ${url})"
+  log fetch "$(display_masked_url "${url}")"
   do_get "${url}" | tar "$tarflag" --strip-components=1 --no-same-owner -f -
   pipe_results=( "${PIPESTATUS[@]}" )
   if [[ "${pipe_results[0]}" -ne 0 ]]; then

--- a/bin/n
+++ b/bin/n
@@ -797,7 +797,7 @@ install() {
   log installing "${g_mirror_folder_name}-v$version"
 
   local url="$(tarball_url "$version")"
-  is_ok "${url}" || abort "download preflight failed for $version $(display_masked_url "${url}")"
+  is_ok "${url}" || abort "download preflight failed for '$version' ($(display_masked_url "${url}"))"
 
   log mkdir "$dir"
   mkdir -p "$dir" || abort "sudo required (or change ownership, or define N_PREFIX)"

--- a/bin/n
+++ b/bin/n
@@ -797,7 +797,7 @@ install() {
   log installing "${g_mirror_folder_name}-v$version"
 
   local url="$(tarball_url "$version")"
-  is_ok "${url}" || abort "download preflight failed for '$version' '$(display_masked_url "${url})"'"
+  is_ok "${url}" || abort "download preflight failed for $version $(display_masked_url "${url}")"
 
   log mkdir "$dir"
   mkdir -p "$dir" || abort "sudo required (or change ownership, or define N_PREFIX)"

--- a/bin/n
+++ b/bin/n
@@ -1498,8 +1498,8 @@ function show_diagnostics() {
   printf "\n\nSETTINGS\n"
 
   printf "\nn\n"
-  echo "node mirror: ${N_NODE_MIRROR}"
-  echo "node downloads mirror: $(masked_url "${N_NODE_DOWNLOAD_MIRROR}")"
+  echo "node mirror: $(masked_url ${N_NODE_MIRROR})"
+  echo "node downloads mirror: $(masked_url ${N_NODE_DOWNLOAD_MIRROR})"
   echo "install destination: ${N_PREFIX}"
   [[ -n "${N_PREFIX}" ]] && echo "PATH: ${PATH}"
   echo "ls-remote max matches: ${N_MAX_REMOTE_MATCHES}"


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request.
-->

mask download url when there is a password.

## Problem

<!--
What problem are you solving? Include issue numbers if it has been reported. 
Show the broken output if appropriate.
-->
When I use export N_NODE_MIRROR with username and password, I found that the password is a plaintext which cause our security concern.
## Solution

<!--
How did you solve the problem? 
Show the fixed output if appropriate.
-->

I introduce a new variable called masked_url, when called log or something want to output the url, can use this variable.

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
