### PR TITLE
Add support for installing unofficial Node.js builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ These Node.js support aliases may be used, although simply resolve to the latest
 The last version form is for specifying [other releases](https://nodejs.org/download) available using the name of the remote download folder optionally followed by the complete or incomplete version.
 
 - `nightly`
+- `unofficial`
 - `test/v11.0.0-test20180528`
 - `rc/10`
 

--- a/bin/n
+++ b/bin/n
@@ -219,6 +219,7 @@ function update_mirror_settings_for_version() {
     g_mirror_folder_name="${remote_folder}"
     g_mirror_url="${N_NODE_DOWNLOAD_MIRROR}/${g_mirror_folder_name}"
   elif is_unofficial "$1"; then
+    g_mirror_folder_name="unofficial"
     g_mirror_url="${N_NODE_UNOFFICIAL_MIRROR}"
   fi
 }

--- a/bin/n
+++ b/bin/n
@@ -80,6 +80,10 @@ N_NODE_DOWNLOAD_MIRROR=${N_NODE_DOWNLOAD_MIRROR:-https://nodejs.org/download}
 N_NODE_DOWNLOAD_MIRROR=${N_NODE_DOWNLOAD_MIRROR%/}
 readonly N_NODE_DOWNLOAD_MIRROR
 
+N_NODE_UNOFFICIAL_MIRROR=${N_NODE_UNOFFICIAL_MIRROR:-https://unofficial-builds.nodejs.org/download/release}
+N_NODE_UNOFFICIAL_MIRROR=${N_NODE_UNOFFICIAL_MIRROR%/}
+readonly N_NODE_UNOFFICIAL_MIRROR
+
 # Using xz instead of gzip is enabled by default, if xz compatibility checks pass.
 # User may set N_USE_XZ to 0 to disable, or set to anything else to enable.
 # May also be overridden by command line flags.
@@ -214,6 +218,8 @@ function update_mirror_settings_for_version() {
     local remote_folder="${BASH_REMATCH[1]}"
     g_mirror_folder_name="${remote_folder}"
     g_mirror_url="${N_NODE_DOWNLOAD_MIRROR}/${g_mirror_folder_name}"
+  elif is_unofficial "$1"; then
+    g_mirror_url="${N_NODE_UNOFFICIAL_MIRROR}"
   fi
 }
 
@@ -258,6 +264,15 @@ function is_lts_codename() {
   # https://github.com/nodejs/Release/blob/master/CODENAMES.md
   # e.g. argon, Boron
   [[ "$1" =~ ^([Aa]rgon|[Bb]oron|[Cc]arbon|[Dd]ubnium|[Ee]rbium|[Ff]ermium|[Gg]allium|[Hh]ydrogen|[Ii]ron|[Jj]od)$ ]]
+}
+
+#
+# Synopsis: is_unofficial version
+#
+
+function is_unofficial() {
+  # e.g. unofficial
+  [[ "$1" == "unofficial" ]]
 }
 
 #
@@ -424,7 +439,7 @@ Versions:
     boron, carbon     Codenames for release streams
     lts_latest        Node.js support aliases
 
-    and nightly, rc/10 et al
+    and nightly, unofficial, rc/10 et al
 
 EOF
 }
@@ -1363,6 +1378,8 @@ function display_remote_versions() {
         match="${match}[^0-9]"
       fi
     fi
+  elif is_unofficial "${version}"; then
+    match='.'
   else
     abort "invalid version '$1'"
   fi
@@ -1496,6 +1513,7 @@ function show_diagnostics() {
   printf "\nn\n"
   echo "node mirror: ${N_NODE_MIRROR}"
   echo "node downloads mirror: ${N_NODE_DOWNLOAD_MIRROR}"
+  echo "node unofficial mirror: ${N_NODE_UNOFFICIAL_MIRROR}"
   echo "install destination: ${N_PREFIX}"
   [[ -n "${N_PREFIX}" ]] && echo "PATH: ${PATH}"
   echo "ls-remote max matches: ${N_MAX_REMOTE_MATCHES}"

--- a/bin/n
+++ b/bin/n
@@ -1309,6 +1309,8 @@ function display_local_versions() {
     match="^${version}/"
   # elif is_download_version "${version}"; then
   # see if demand
+  elif is_unofficial "${version}"; then
+    match="^${version}/"
   else
     abort "invalid version '$1' for offline matching"
   fi

--- a/bin/n
+++ b/bin/n
@@ -216,8 +216,13 @@ function update_mirror_settings_for_version() {
   elif is_download_version "$1"; then
     [[ "$1" =~ ^([^/]+)/(.*) ]]
     local remote_folder="${BASH_REMATCH[1]}"
-    g_mirror_folder_name="${remote_folder}"
-    g_mirror_url="${N_NODE_DOWNLOAD_MIRROR}/${g_mirror_folder_name}"
+    if is_download_folder "$remote_folder"; then
+      g_mirror_folder_name="${remote_folder}"
+      g_mirror_url="${N_NODE_DOWNLOAD_MIRROR}/${g_mirror_folder_name}"
+    elif is_unofficial "$remote_folder"; then
+      g_mirror_folder_name="unofficial"
+      g_mirror_url="${N_NODE_UNOFFICIAL_MIRROR}"
+    fi
   elif is_unofficial "$1"; then
     g_mirror_folder_name="unofficial"
     g_mirror_url="${N_NODE_UNOFFICIAL_MIRROR}"
@@ -293,7 +298,7 @@ function is_download_version() {
   # e.g. nightly/, nightly/latest, nightly/v11
   if [[ "$1" =~ ^([^/]+)/(.*) ]]; then
     local remote_folder="${BASH_REMATCH[1]}"
-    is_download_folder "${remote_folder}"
+    is_download_folder "${remote_folder}" || is_unofficial "${remote_folder}"
     return
   fi
   return 2


### PR DESCRIPTION
This PR adds support for installing unofficial Node.js builds using `n`.

I needed to install the latest Node.js version on a legacy architecture, but official binaries weren't available. I had to manually search for and download unofficial builds. 

This enhancement would streamline the process by allowing users to install unofficial builds directly through `n`, making it more versatile and convenient. 