### PR TITLE
Add --cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To take ownership of the system directories (option 1):
 
 If `npm` is not yet available, one way to bootstrap an install is to download and run `n` directly. To install the `lts` version of Node.js:
 
-    curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s lts
+    curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s install lts
     # If you want n installed, you can use npm now.
     npm install -g n
 
@@ -236,6 +236,18 @@ List downloaded versions in cache:
 Use `n` to access cached versions (already downloaded) without internet available.
 
     n --offline 12
+
+Remove the cache version after installing using `--cleanup`. This is particularly useful for a one-shot install, like in a docker container.
+
+    curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s install --cleanup lts
+
+The `--download` option can be used in two ways, to download a version into cache but not make active:
+
+    n --download lts
+
+or to download a possibly missing version for  `n run`, `n exec`, and `n which`:
+
+    n --download run 18.3 my-script.js
 
 Display diagnostics to help resolve problems:
 

--- a/bin/n
+++ b/bin/n
@@ -133,6 +133,7 @@ g_active_node=
 g_target_node=
 
 DOWNLOAD=false # set to opt-out of activate (install), and opt-in to download (run, exec)
+CLEANUP=false # remove cached download after install
 ARCH=
 SHOW_VERBOSE_LOG="true"
 OFFLINE=false
@@ -395,13 +396,14 @@ Options:
   -V, --version         Output version of n
   -h, --help            Display help information
   -p, --preserve        Preserve npm and npx during install of Node.js
-  -q, --quiet           Disable curl output. Disable log messages processing "auto" and "engine" labels.
+  -q, --quiet           Disable curl output. Disable log messages processing "auto" and "engine" labels
   -d, --download        Download if necessary, and don't make active
+  --cleanup             Remove cached version after install
   -a, --arch            Override system architecture
   --offline             Resolve target version against cached downloads instead of internet lookup
   --all                 ls-remote displays all matches instead of last 20
   --insecure            Turn off certificate checking for https requests (may be needed from behind a proxy server)
-  --use-xz/--no-use-xz  Override automatic detection of xz support and enable/disable use of xz compressed node downloads.
+  --use-xz/--no-use-xz  Override automatic detection of xz support and enable/disable use of xz compressed node downloads
 
 Aliases:
 
@@ -757,6 +759,12 @@ activate() {
       printf 'If "node --version" shows the old version then start a new shell, or reset the location hash with:\nhash -r  (for bash, zsh, ash, dash, and ksh)\nrehash   (for csh and tcsh)\n'
     fi
   fi
+
+  if [[ "$CLEANUP" == "true" ]]; then
+    log "cleanup" "removing cached $version"
+    remove_versions "$version"
+  fi
+
 }
 
 #
@@ -1672,6 +1680,7 @@ while [[ $# -ne 0 ]]; do
     -h|--help|help) display_help; exit ;;
     -q|--quiet) set_quiet ;;
     -d|--download) DOWNLOAD="true" ;;
+    --cleanup) CLEANUP="true" ;;
     --offline) OFFLINE="true" ;;
     --insecure) set_insecure ;;
     -p|--preserve) N_PRESERVE_NPM="true" N_PRESERVE_COREPACK="true" ;;

--- a/bin/n
+++ b/bin/n
@@ -396,14 +396,14 @@ Options:
   -V, --version         Output version of n
   -h, --help            Display help information
   -p, --preserve        Preserve npm and npx during install of Node.js
-  -q, --quiet           Disable curl output. Disable log messages processing "auto" and "engine" labels
+  -q, --quiet           Disable curl output. Disable log messages processing "auto" and "engine" labels.
   -d, --download        Download if necessary, and don't make active
   --cleanup             Remove cached version after install
   -a, --arch            Override system architecture
   --offline             Resolve target version against cached downloads instead of internet lookup
   --all                 ls-remote displays all matches instead of last 20
   --insecure            Turn off certificate checking for https requests (may be needed from behind a proxy server)
-  --use-xz/--no-use-xz  Override automatic detection of xz support and enable/disable use of xz compressed node downloads
+  --use-xz/--no-use-xz  Override automatic detection of xz support and enable/disable use of xz compressed node downloads.
 
 Aliases:
 


### PR DESCRIPTION
# Pull Request

## Problem

Multiple commands are needed to do a one-shot install without leaving behind an extra copy in the cache folder. This came up in context of docker container setup.

See: #809

## Solution

Add `--cleanup` which will delete cached version after install.

```console
% n install --cleanup 20.0.0
  installing : node-v20.0.0
       mkdir : /usr/local/n/versions/node/20.0.0
       fetch : https://nodejs.org/dist/v20.0.0/node-v20.0.0-darwin-arm64.tar.xz
     copying : node/20.0.0
   installed : v20.0.0 (with npm 9.6.4)
     cleanup : removing cached node/20.0.0
```

## ChangeLog

- Added: `--cleanup` to delete cached version after install for a one-shot install