### PR TITLE
Add support for trailing comment in .nvmrc

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -1147,6 +1147,8 @@ function get_nvmrc_version() {
   verbose_log "found" "${filepath}"
   local version
   <"${filepath}" read -r version
+  # remove trailing comment, after #
+  version="$(echo "${version}" | sed 's/[[:space:]]*#.*//')"
   verbose_log "read" "${version}"
   # Translate from nvm aliases
   case "${version}" in

--- a/test/tests/version-resolve-auto-nvmrc.bats
+++ b/test/tests/version-resolve-auto-nvmrc.bats
@@ -68,3 +68,11 @@ function setup() {
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.11.1"
 }
+
+@test "auto .nvmrc, trailing comment" {
+  local TARGET_VERSION="8.10.0"
+  cd "${MY_DIR}"
+  printf "${TARGET_VERSION} # comment" > .nvmrc
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "${TARGET_VERSION}"
+}


### PR DESCRIPTION
# Pull Request

## Problem

`nvm` now supports comments, ignoring text following a `#`

## Solution

Strip text after `#` when reading file.

## ChangeLog

- support comments in `.nvmrc` file, ignoring text following `#` character