### PR TITLE
Add download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ List downloaded versions in cache:
 
     n ls
 
+Download version into cache:
+
+    n download 22
+
 Use `n` to access cached versions (already downloaded) without internet available.
 
     n --offline 12

--- a/bin/n
+++ b/bin/n
@@ -390,6 +390,7 @@ Commands:
   n ls                           Output downloaded versions
   n ls-remote [version]          Output matching versions available for download
   n uninstall                    Remove the installed Node.js
+  n download <version>           Download Node.js <version> into cache
 
 Options:
 
@@ -794,6 +795,8 @@ install() {
     if [[ ! -e "$dir/n.lock" ]] ; then
       if [[ "$DOWNLOAD" == "false" ]] ; then
         activate "${g_mirror_folder_name}/${version}"
+      else
+        log downloaded "${g_mirror_folder_name}/${version} already in cache"
       fi
       exit
     fi
@@ -802,7 +805,11 @@ install() {
     abort "version unavailable offline"
   fi
 
-  log installing "${g_mirror_folder_name}-v$version"
+  if [[ "$DOWNLOAD" == "false" ]]; then
+    log installing "${g_mirror_folder_name}-v$version"
+  else
+    log download "${g_mirror_folder_name}-v$version"
+  fi
 
   local url="$(tarball_url "$version")"
   is_ok "${url}" || abort "download preflight failed for '$version' ($(display_masked_url "${url}"))"
@@ -1733,6 +1740,7 @@ else
     lsr|ls-remote|list-remote) shift; display_remote_versions "$1"; exit ;;
     uninstall) uninstall_installed; exit ;;
     i|install) shift; install "$1"; exit ;;
+    download) shift; DOWNLOAD="true"; install "$1"; exit ;;
     N_TEST_DISPLAY_LATEST_RESOLVED_VERSION) shift; get_latest_resolved_version "$1" > /dev/null || exit 2; echo "${g_target_node}"; exit ;;
     *) install "$1"; exit ;;
   esac

--- a/test/tests/install-options.bats
+++ b/test/tests/install-options.bats
@@ -17,9 +17,22 @@ function teardown() {
 
 
 @test "n --download 4.9.1" {
+  # deprecated use of --download, replaced by download command
   n --download 4.9.1
   [ -d "${N_PREFIX}/n/versions/node/4.9.1" ]
-  # Remember, we installed a dummy node so do have a bin/node
+  [ ! -f "${N_PREFIX}/bin/node" ]
+  [ ! -f "${N_PREFIX}/bin/npm" ]
+  [ ! -d "${N_PREFIX}/include" ]
+  [ ! -d "${N_PREFIX}/lib" ]
+  [ ! -d "${N_PREFIX}/shared" ]
+}
+
+
+@test "n download 4.9.1" {
+  # not an option, but keep with --download so stays in sync
+  n download 4.9.1
+  [ -d "${N_PREFIX}/n/versions/node/4.9.1" ]
+  [ ! -f "${N_PREFIX}/bin/node" ]
   [ ! -f "${N_PREFIX}/bin/npm" ]
   [ ! -d "${N_PREFIX}/include" ]
   [ ! -d "${N_PREFIX}/lib" ]
@@ -32,6 +45,14 @@ function teardown() {
   n --quiet 4.9.1
   output="$(node --version)"
   assert_equal "${output}" "v4.9.1"
+}
+
+
+@test "n --cleanup 4.9.1" {
+  n install --cleanup 4.9.1
+  output="$(node --version)"
+  assert_equal "${output}" "v4.9.1"
+  [ ! -d "${N_PREFIX}/n/versions/node/4.9.1" ]
 }
 
 

--- a/test/tests/offline.bats
+++ b/test/tests/offline.bats
@@ -8,7 +8,7 @@ function setup_file() {
   unset_n_env
   setup_tmp_prefix
   # Note, NOT latest version of 16.
-  n --download 16.19.0
+  n download 16.19.0
   export N_NODE_MIRROR="https://no.internet.available"
 }
 

--- a/test/tests/run-which.bats
+++ b/test/tests/run-which.bats
@@ -9,8 +9,8 @@ function setup_file() {
   # fixed directory so can reuse the two installs
   tmpdir="${TMPDIR:-/tmp}"
   export N_PREFIX="${tmpdir}/n/test/run-which"
-  n --download 4.9.1
-  n --download lts
+  n download 4.9.1
+  n download lts
   # using "latest" for download tests with run and exec
 }
 


### PR DESCRIPTION
# Pull Request

## Problem

`--download` means download-if-necessary when used with run/exec/which.

The original use of `--download` was for `n --download lts`, like a command, but that usage is now a bit weird and inconsistent with explicit install like `n --download install lts`.

## Solution

Add explicit `download` command.

The original use of `n --download <version>` still works as it did, but is no longer mentioned in the README or help. Soft deprecated.

## ChangeLog

- add `download` command
