### PR TITLE
Add unofficial builds as example mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Node.js version management: no subshells, no profile setup, no convoluted API, j
     - [Using Downloaded Node.js Versions Without Reinstalling](#using-downloaded-nodejs-versions-without-reinstalling)
     - [Preserving npm](#preserving-npm)
     - [Miscellaneous](#miscellaneous)
-    - [Custom Source](#custom-source)
+    - [Custom Mirror](#custom-mirror)
     - [Custom Architecture](#custom-architecture)
     - [Optional Environment Variables](#optional-environment-variables)
     - [How It Works](#how-it-works)
@@ -250,12 +250,18 @@ Display diagnostics to help resolve problems:
 
     n doctor
 
-## Custom Source
+## Custom Mirror
 
 If you would like to use a different Node.js mirror which has the same layout as the default <https://nodejs.org/dist/>, you can define `N_NODE_MIRROR`.
-The most common example is from users in China who can define:
+
+One example is for users in China who can define:
 
     export N_NODE_MIRROR=https://npmmirror.com/mirrors/node
+
+Another example is the Node.js [unofficial-builds project](https://github.com/nodejs/unofficial-builds/) which has downloads for some platforms not made available officially. Auto-detected architectures like x86 or  armv6l (Raspberry Pi) need no further setup with `n`, or you can specify the architecture explicitly using `--arch` like using `musl` `libc` on Alpine. (See also [Builds](https://github.com/nodejs/unofficial-builds/#builds) for further details.)
+
+    export N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release
+    n --arch x64-musl install lts
 
 If the custom mirror requires authentication you can add the [url-encoded](https://urlencode.org) username and password into the URL. e.g.
 

--- a/README.md
+++ b/README.md
@@ -258,10 +258,14 @@ One example is for users in China who can define:
 
     export N_NODE_MIRROR=https://npmmirror.com/mirrors/node
 
-Another example is the Node.js [unofficial-builds project](https://github.com/nodejs/unofficial-builds/) which has downloads for some platforms not made available officially. Auto-detected architectures like x86 or  armv6l (Raspberry Pi) need no further setup with `n`, or you can specify the architecture explicitly using `--arch` like using `musl` `libc` on Alpine. (See also [Builds](https://github.com/nodejs/unofficial-builds/#builds) for further details.) Alpine example:
+Another example is the Node.js [unofficial-builds project](https://github.com/nodejs/unofficial-builds/) which has downloads for some platforms not made available officially, such as armv6l (Raspberry Pi) and 32-bit x86.
 
-    apk add bash curl libstdc++
     export N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release
+
+You may need to specify the architecture explicitly if not autodetected by `n`, such as using `musl` `libc` on Alpine.
+
+    export N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release
+    apk add bash curl libstdc++
     n --arch x64-musl install lts
 
 If the custom mirror requires authentication you can add the [url-encoded](https://urlencode.org) username and password into the URL. e.g.

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Another example is the Node.js [unofficial-builds project](https://github.com/no
 
     export N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release
 
-You may need to specify the architecture explicitly if not autodetected by `n`, such as using `musl` `libc` on Alpine.
+You may need to specify the architecture explicitly if not autodetected by `n`, such as using `musl` `libc` on Alpine:
 
     export N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release
     apk add bash curl libstdc++

--- a/README.md
+++ b/README.md
@@ -258,8 +258,9 @@ One example is for users in China who can define:
 
     export N_NODE_MIRROR=https://npmmirror.com/mirrors/node
 
-Another example is the Node.js [unofficial-builds project](https://github.com/nodejs/unofficial-builds/) which has downloads for some platforms not made available officially. Auto-detected architectures like x86 or  armv6l (Raspberry Pi) need no further setup with `n`, or you can specify the architecture explicitly using `--arch` like using `musl` `libc` on Alpine. (See also [Builds](https://github.com/nodejs/unofficial-builds/#builds) for further details.)
+Another example is the Node.js [unofficial-builds project](https://github.com/nodejs/unofficial-builds/) which has downloads for some platforms not made available officially. Auto-detected architectures like x86 or  armv6l (Raspberry Pi) need no further setup with `n`, or you can specify the architecture explicitly using `--arch` like using `musl` `libc` on Alpine. (See also [Builds](https://github.com/nodejs/unofficial-builds/#builds) for further details.) Alpine example:
 
+    apk add bash curl libstdc++
     export N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release
     n --arch x64-musl install lts
 


### PR DESCRIPTION
# Pull Request

## Problem

Alpine and Raspberry Pi users and 32-bit x86 and other officially unsupported architectures can use unofficial builds, but don't want to use that by default.

See: #274 https://github.com/tj/n/issues/492#issuecomment-450585623 https://github.com/tj/n/issues/517#issuecomment-450586230 #648 #816 

## Solution

Add unofficial builds as an example of using mirror.