### PR TITLE
Add option to open a subshell with desired nodejs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ wish to use node and npm, or are switching to a different way of managing them.
 
 ## Using Downloaded Node.js Versions Without Reinstalling
 
-There are three commands for working directly with your downloaded versions of Node.js, without reinstalling.
+There are four commands for working directly with your downloaded versions of Node.js, without reinstalling.
 
 You can show the path to the downloaded `node` version:
 
@@ -194,6 +194,10 @@ Or execute a command with `PATH` modified so `node` and `npm` will be from the d
 
     n exec 10 my-script --fast test
     n exec lts zsh
+
+Or open a subshell with `PATH` modified so `node` and `npm` will be from the downloaded Node.js version.
+
+    n shell 14
 
 ## Preserving npm
 

--- a/bin/n
+++ b/bin/n
@@ -383,6 +383,7 @@ Commands:
   n run <version> [args ...]     Execute downloaded Node.js <version> with [args ...]
   n which <version>              Output path for downloaded node <version>
   n exec <vers> <cmd> [args...]  Execute command with modified PATH, so downloaded node <version> and npm first
+  n shell <version>              Open a new shell with modified PATH, so downloaded node <version> and npm first
   n rm <version ...>             Remove the given downloaded version(s)
   n prune                        Remove all downloaded versions except the installed version
   n --latest                     Output the latest Node.js version available
@@ -971,6 +972,16 @@ function exec_with_version() {
   find_cached_version "$1"
   shift # remove version from parameters
   PATH="${g_cached_version}/bin:$PATH" exec "$@"
+}
+
+#
+# Synopsis: shell_with_version <version>
+# Modify the path to include <version> and open new shell.
+#
+
+function shell_with_version() {
+  find_cached_version "$1"
+  bash --rcfile <(echo "[ -f ~/.bashrc ] && source ~/.bashrc; export PATH=\"${g_cached_version}/bin:$PATH}\"; export PS1=\"(nodejs ${g_target_node}) \$PS1\"")
 }
 
 #
@@ -1730,6 +1741,7 @@ else
     bin|which) display_bin_path_for_version "$2"; exit ;;
     run|as|use) shift; run_with_version "$@"; exit ;;
     exec) shift; exec_with_version "$@"; exit ;;
+    shell) shift; shell_with_version "$@"; exit ;;
     doctor) show_diagnostics; exit ;;
     rm|-) shift; remove_versions "$@"; exit ;;
     prune) prune_cache; exit ;;


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request.
-->

## Problem

I frequently have to work with multiple nodejs versions at the same time (for example frontend works with nodejs 20, backend need 16). `n exec 16 bash` works, but then I don't know what nodejs version is used in that terminal window.

<!--
What problem are you solving? Include issue numbers if it has been reported. 
Show the broken output if appropriate.
-->

## Solution

Added a new command `n shell <version>` which modifies the PATH and PS1

<!--
How did you solve the problem? 
Show the fixed output if appropriate.
-->

## ChangeLog

Added new command to open subshell with specific nodejs version

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
