### PR TITLE
Add `dir` output when using `--download` and directory exists

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -797,6 +797,7 @@ install() {
         activate "${g_mirror_folder_name}/${version}"
       else
         log downloaded "${g_mirror_folder_name}/${version} already in cache"
+        log dir "$dir"
       fi
       exit
     fi


### PR DESCRIPTION
This is the tiny change that I talked about in #831. The actual change is both the extra line, plus a vague highlevel decision to keep this output intact in face of future change.

Looks like a very small change (which I promised :) and also likely to be accepted since it's a harmless one line of output --- BUT --- with this, I can use `n` to manage the downloading + caching of various versions, but use my own system for actually "activating" it.

In my use case, I'd write a small script that uses `n <ver> --quiet --download` to just have some version available. With this PR in place, I can parse the output and look for `^ *(mk)?dir : `. That gives me the directory which I will then use as a `/usr/local/node` symlink (with `/usr/local/bin/*` symlinks into that main `node` symlink).

AAt a higher level, this makes it possible to use the download-and-cache functionality of `n` with any way of using the results. This could open up more uses in the future to have more alternative activations.

I specifically think now that some disconnected `n link <ver>` would be an awkward addition, since it would look like a side-think that is bolted on, since it would be disconnected from the main way of activating a version. That's why I originally thought about something along the lines of adding a "mode" thing, but as I said in that thread, that would be a major change. Especially with things like `--cleanup` that won't fit with it.

At a minimum, it would make it easy to play with alterrnative activations before adding it to the main code.
