### PR TITLE
Lazy updates

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -1233,13 +1233,8 @@ function version_satisfies_target() {
   current="${current#v}"
   target="${target#v}"
   
-  # Exact match
-  if [[ "${current}" == "${target}" ]]; then
-    return 0
-  fi
-  
-  # Wildcard
-  if [[ "*" == "${target}" ]]; then
+  # Exact match or wildcard
+  if [[ "$current" == "$target" || $target == "*" ]]; then
     return 0
   fi
   
@@ -1249,7 +1244,7 @@ function version_satisfies_target() {
     local version="${BASH_REMATCH[2]}"
 
     case "${operator}" in
-      '')
+      '' | =)
         # e.g. "22" matches 22.x.x, "22.21" matches 22.21.x, etc.
         if [[ "${version}" =~ ^[0-9]+$ ]]; then
           [[ "${current%%.*}" == "${version}" ]]
@@ -1258,9 +1253,6 @@ function version_satisfies_target() {
         else
           [[ "${current}" == "${version}" ]]
         fi
-        ;;
-      =)
-        [[ "${current}" == "${version}" ]]
         ;;
     \>) version_gte "${current}" "${version}" && [[ "${current}" != "${version}" ]] ;;
     \>=) version_gte "${current}" "${version}" ;;

--- a/bin/n
+++ b/bin/n
@@ -1234,11 +1234,9 @@ function version_satisfies_target() {
   # Remove 'v' prefix if present
   current="${current#v}"
   target="${target#v}"
-  
-  # Exact match or wildcard
-  if [[ "$current" == "$target" || $target == "*" ]]; then
-    return 0
-  fi
+
+  [[ -z "${target}" ]] && return 1
+  [[ "${current}" == "${target}" || "${target}" == "*" ]] && return 0
   
   # Check for operator-based range (only supports what get_package_engine_version does)
   if [[ "${target}" =~ ^([>~^=]|\>\=)?v?([0-9]+(\.[0-9]+){0,2})(.[xX*])?$ ]]; then
@@ -1335,11 +1333,14 @@ function get_latest_resolved_version() {
   fi
 
   if [[ -z "${g_if_needed_node}" ]]; then
-    if ! is_numeric_version "${version}" && [[ "${version}" != "latest" && "${version}" != "current" ]]; then
+    if is_numeric_version "${version}"; then
+      g_if_needed_node="${version}"
+    elif is_lts_codename "${version}" || [[ "${version}" = "lts" ]]; then
       # Codenames (e.g. "argon") will only if-needed match major rather than latest minor/patch
       g_if_needed_node=$(display_major_version "${g_target_node}")
     else
-      g_if_needed_node="${version}"
+      # Other strings (e.g. latest, nightly, rc) should never skip updates
+      g_if_needed_node=""
     fi
   fi
 }

--- a/bin/n
+++ b/bin/n
@@ -789,7 +789,6 @@ install() {
   if [[ "$LAZY" == "true" ]]; then
     if [[ -n "${current_version}" ]]; then
       verbose_log "lazy" "${g_lazy_node}"
-      verbose_log "lazy2" "${g_lazy_node:=$version}"
       if version_satisfies_target "${current_version}" "${g_lazy_node}"; then
         echo "Current version ${current_version} satisfies requirement ${g_lazy_node}"
         return 0
@@ -1336,10 +1335,6 @@ function get_latest_resolved_version() {
     version="${g_target_node}"
   fi
 
-  if is_numeric_version "${version}"; then
-    g_lazy_node="${version}"
-  fi
-
   simple_version=${version#node/} # Only place supporting node/ [sic]
   if is_exact_numeric_version "${simple_version}"; then
     # Just numbers, already resolved, no need to lookup first.
@@ -1350,6 +1345,15 @@ function get_latest_resolved_version() {
   else
     # Complicated recognising exact version, KISS and lookup.
     g_target_node=$(N_MAX_REMOTE_MATCHES=1 display_remote_versions "$version")
+  fi
+
+  if [[ -z "${g_lazy_node}" ]]; then
+    if ! is_numeric_version "${version}" && [[ "${version}" != "latest" && "${version}" != "current" ]]; then
+      # Codenames (e.g. "argon") will only lazy match major rather than latest minor/patch
+      g_lazy_node=$(display_major_version "${g_target_node}")
+    else
+      g_lazy_node="${version}"
+    fi
   fi
 }
 

--- a/bin/n
+++ b/bin/n
@@ -1339,7 +1339,7 @@ function get_latest_resolved_version() {
       # Codenames (e.g. "argon") will only if-needed match major rather than latest minor/patch
       g_if_needed_node=$(display_major_version "${g_target_node}")
     elif [[ "${version}" = "lts" ]]; then
-      g_if_needed_node=">=$(get_latest_lts_lowest_version)"
+      g_if_needed_node="^$(get_latest_lts_lowest_version)"
     else
       # Other strings (e.g. latest, nightly, rc) should never skip updates
       g_if_needed_node=""

--- a/bin/n
+++ b/bin/n
@@ -132,8 +132,12 @@ g_active_node=
 # set by various lookups to allow mixed logging and return value from function, especially for engine and node
 g_target_node=
 
+# Like g_target_node, but retained granularity differs based on context
+g_lazy_node=
+
 DOWNLOAD=false # set to opt-out of activate (install), and opt-in to download (run, exec)
 CLEANUP=false # remove cached download after install
+LAZY=false # check if current version satisfies requirement before installing
 ARCH="${N_ARCH-}"
 SHOW_VERBOSE_LOG="true"
 OFFLINE=false
@@ -402,6 +406,7 @@ Options:
   --cleanup             Remove cached version after install
   -a, --arch            Override system architecture
   --offline             Resolve target version against cached downloads instead of internet lookup
+  --lazy                Skip install if current version already "good enough"
   --all                 ls-remote displays all matches instead of last 20
   --insecure            Turn off certificate checking for https requests (may be needed from behind a proxy server)
   --use-xz/--no-use-xz  Override automatic detection of xz support and enable/disable use of xz compressed node downloads.
@@ -778,6 +783,20 @@ install() {
   get_latest_resolved_version "$1" || return 2
   version="${g_target_node}"
   [[ -n "${version}" ]] || abort "no version found for '$1'"
+  
+  local current_version="$(node --version 2>/dev/null)"
+  verbose_log "current" "${current_version}"
+  if [[ "$LAZY" == "true" ]]; then
+    if [[ -n "${current_version}" ]]; then
+      verbose_log "lazy" "${g_lazy_node}"
+      verbose_log "lazy2" "${g_lazy_node:=$version}"
+      if version_satisfies_target "${current_version}" "${g_lazy_node}"; then
+        echo "Current version ${current_version} satisfies requirement ${g_lazy_node}"
+        return 0
+      fi
+    fi
+  fi
+  
   update_mirror_settings_for_version "$1"
   update_xz_settings_for_version "${version}"
   update_arch_settings_for_version "${version}"
@@ -1106,6 +1125,7 @@ function get_file_node_version() {
 
 function get_package_engine_version() {
   g_target_node=
+  g_lazy_node=
   local filepath="$1"
   verbose_log "found" "${filepath}"
   local range
@@ -1118,6 +1138,7 @@ function get_package_engine_version() {
   fi
   verbose_log "read" "${range}"
   [[ -n "${range}" ]] || return 2
+  g_lazy_node="${range}" # Store range before we start replacing numbers with "current"
   if [[ "*" == "${range}" ]]; then
     verbose_log "target" "current"
     g_target_node="current"
@@ -1196,6 +1217,80 @@ function get_engine_version() {
 }
 
 #
+# Synopsis: version_satisfies_target current target
+# Check if current version satisfies the given target version or range.
+#
+
+function version_satisfies_target() {
+  local current="$1"
+  local target="$2"
+  
+  # Remove 'v' prefix if present
+  current="${current#v}"
+  target="${target#v}"
+  
+  # Exact match
+  if [[ "${current}" == "${target}" ]]; then
+    return 0
+  fi
+  
+  # Wildcard
+  if [[ "*" == "${target}" ]]; then
+    return 0
+  fi
+  
+  # Check for operator-based range
+  if [[ "${target}" =~ ^([>~^=]|\>\=)?v?([0-9]+(\.[0-9]+){0,2})(.[xX*])?$ ]]; then
+    local operator="${BASH_REMATCH[1]}"
+    local version="${BASH_REMATCH[2]}"
+    verbose_log "operator" "${operator}"
+    verbose_log "version" "${version}"
+
+    case "${operator}" in
+      '')
+        # e.g. "22" matches 22.x.x, "22.21" matches 22.21.x, etc.
+        if [[ "${version}" =~ ^[0-9]+$ ]]; then
+          local current_major="${current%%.*}"
+          [[ "${current_major}" == "${version}" ]]
+        elif [[ "${version}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+          local current_major_minor="${current%.*}"
+          [[ "${current_major_minor}" == "${version}" ]]
+        else
+          [[ "${current}" == "${version}" ]]
+        fi
+        ;;
+      =)
+        [[ "${current}" == "${version}" ]]
+        ;;
+      \>) [[ "$(printf '%s\n%s' "${current}" "${version}" | sort -V | tail -n1)" == "${current}" && "${current}" != "${version}" ]] ;;
+      \>=) [[ "$(printf '%s\n%s' "${current}" "${version}" | sort -V | tail -n1)" == "${current}" ]] ;;
+      \~) 
+        # Tilde allows patch-level changes if version has patch, or minor+patch if version has no patch
+        if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          local current_major_minor="${current%.*}"
+          local target_major_minor="${version%.*}"
+          [[ "${current_major_minor}" == "${target_major_minor}" && "$(printf '%s\n%s' "${current}" "${version}" | sort -V | tail -n1)" == "${current}" ]]
+        else
+          local current_major="${current%%.*}"
+          local target_major="${version%%.*}"
+          [[ "${current_major}" == "${target_major}" ]]
+        fi
+        ;;
+      ^)
+        # Caret allows minor and patch changes
+        local current_major="${current%%.*}"
+        local target_major="${version%%.*}"
+        [[ "${current_major}" == "${target_major}" && "$(printf '%s\n%s' "${current}" "${version}" | sort -V | tail -n1)" == "${current}" ]]
+        ;;
+    esac
+  else
+    # Complex range, use npx semver for checking
+    command -v npx &> /dev/null || return 1
+    npx --quiet semver@7 "${current}" -r "${target}" &> /dev/null
+  fi
+}
+
+#
 # Synopsis: get_auto_version
 # Sets g_target_node
 #
@@ -1239,6 +1334,10 @@ function get_latest_resolved_version() {
   elif [[ "${version}" = "engine" ]]; then
     get_engine_version || return 2
     version="${g_target_node}"
+  fi
+
+  if is_numeric_version "${version}"; then
+    g_lazy_node="${version}"
   fi
 
   simple_version=${version#node/} # Only place supporting node/ [sic]
@@ -1702,6 +1801,7 @@ while [[ $# -ne 0 ]]; do
     --no-preserve) N_PRESERVE_NPM="" N_PRESERVE_COREPACK="" ;;
     --use-xz) N_USE_XZ="true" ;;
     --no-use-xz) N_USE_XZ="false" ;;
+    --lazy) LAZY="true" ;;
     --latest) display_remote_versions latest; exit ;;
     --stable) display_remote_versions lts; exit ;; # [sic] old terminology
     --lts) display_remote_versions lts; exit ;;

--- a/bin/n
+++ b/bin/n
@@ -202,6 +202,13 @@ display_major_version() {
     echo "${version}"
 }
 
+#
+# Synposis: return if a $1 >= $2, given values like x.y.z
+#
+version_gte() {
+  [[ "$(printf '%s\n%s' "$1" "$2" | sort -V | tail -n1)" == "$1" ]]
+}
+
 display_masked_url() {
   echo "$1" | sed -r 's/(https?:\/\/[^:]+):([^@]+)@/\1:****@/'
 }
@@ -1239,7 +1246,7 @@ function version_satisfies_target() {
   fi
   
   # Check for operator-based range (only supports what get_package_engine_version does)
-  if [[ "${target}" =~ ^([>~^=]|\>\=)?v?([0-9]+(\.[0-9]+){0,2})(.[xX*])?$ ]]; then
+  if [[ "${target}" =~ ^([>=]|\>\=)?v?([0-9]+(\.[0-9]+){0,2})(.[xX*])?$ ]]; then
     local operator="${BASH_REMATCH[1]}"
     local version="${BASH_REMATCH[2]}"
 
@@ -1247,11 +1254,9 @@ function version_satisfies_target() {
       '')
         # e.g. "22" matches 22.x.x, "22.21" matches 22.21.x, etc.
         if [[ "${version}" =~ ^[0-9]+$ ]]; then
-          local current_major="${current%%.*}"
-          [[ "${current_major}" == "${version}" ]]
+          [[ "${current%%.*}" == "${version}" ]]
         elif [[ "${version}" =~ ^[0-9]+\.[0-9]+$ ]]; then
-          local current_major_minor="${current%.*}"
-          [[ "${current_major_minor}" == "${version}" ]]
+          [[ "${current%.*}" == "${version}" ]]
         else
           [[ "${current}" == "${version}" ]]
         fi
@@ -1259,26 +1264,8 @@ function version_satisfies_target() {
       =)
         [[ "${current}" == "${version}" ]]
         ;;
-      \>) [[ "$(printf '%s\n%s' "${current}" "${version}" | sort -V | tail -n1)" == "${current}" && "${current}" != "${version}" ]] ;;
-      \>=) [[ "$(printf '%s\n%s' "${current}" "${version}" | sort -V | tail -n1)" == "${current}" ]] ;;
-      \~) 
-        # Tilde allows patch-level changes if version has patch, or minor+patch if version has no patch
-        if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          local current_major_minor="${current%.*}"
-          local target_major_minor="${version%.*}"
-          [[ "${current_major_minor}" == "${target_major_minor}" && "$(printf '%s\n%s' "${current}" "${version}" | sort -V | tail -n1)" == "${current}" ]]
-        else
-          local current_major="${current%%.*}"
-          local target_major="${version%%.*}"
-          [[ "${current_major}" == "${target_major}" ]]
-        fi
-        ;;
-      ^)
-        # Caret allows minor and patch changes
-        local current_major="${current%%.*}"
-        local target_major="${version%%.*}"
-        [[ "${current_major}" == "${target_major}" && "$(printf '%s\n%s' "${current}" "${version}" | sort -V | tail -n1)" == "${current}" ]]
-        ;;
+    \>) [[ $(version_gte "${current}" "${version}") && "${current}" != "${version}" ]] ;;
+    \>=) [[ $(version_gte "${current}" "${version}") ]] ;;
     esac
   else
     # Complex range, use npx semver for checking

--- a/bin/n
+++ b/bin/n
@@ -1262,8 +1262,8 @@ function version_satisfies_target() {
       =)
         [[ "${current}" == "${version}" ]]
         ;;
-    \>) [[ $(version_gte "${current}" "${version}") && "${current}" != "${version}" ]] ;;
-    \>=) [[ $(version_gte "${current}" "${version}") ]] ;;
+    \>) version_gte "${current}" "${version}" && [[ "${current}" != "${version}" ]] ;;
+    \>=) version_gte "${current}" "${version}" ;;
     esac
   else
     # Complex range, use npx semver for checking

--- a/bin/n
+++ b/bin/n
@@ -1238,12 +1238,10 @@ function version_satisfies_target() {
     return 0
   fi
   
-  # Check for operator-based range
+  # Check for operator-based range (only supports what get_package_engine_version does)
   if [[ "${target}" =~ ^([>~^=]|\>\=)?v?([0-9]+(\.[0-9]+){0,2})(.[xX*])?$ ]]; then
     local operator="${BASH_REMATCH[1]}"
     local version="${BASH_REMATCH[2]}"
-    verbose_log "operator" "${operator}"
-    verbose_log "version" "${version}"
 
     case "${operator}" in
       '')

--- a/bin/n
+++ b/bin/n
@@ -1341,8 +1341,8 @@ function get_latest_resolved_version() {
     elif [[ "${version}" = "lts" ]]; then
       g_if_needed_node="^$(get_latest_lts_lowest_version)"
     else
-      # Other strings (e.g. latest, nightly, rc) should never skip updates
-      g_if_needed_node=""
+      # Other string targets (e.g. latest, nightly, rc)
+      g_if_needed_node="${g_target_node}"
     fi
   fi
 }

--- a/bin/n
+++ b/bin/n
@@ -206,7 +206,9 @@ display_major_version() {
 # Synposis: return if a $1 >= $2, given values like x.y.z
 #
 version_gte() {
-  [[ "$(printf '%s\n%s' "$1" "$2" | sort -V | tail -n1)" == "$1" ]]
+  [[ "$(printf '%s\n%s' "$1" "$2" \
+    | sort  -k1,1n -k2,2n -k3,3n -k4,4n -t . \
+    | tail -n1)" == "$1" ]]
 }
 
 display_masked_url() {

--- a/bin/n
+++ b/bin/n
@@ -1241,7 +1241,7 @@ function version_satisfies_target() {
   fi
   
   # Check for operator-based range (only supports what get_package_engine_version does)
-  if [[ "${target}" =~ ^([>=]|\>\=)?v?([0-9]+(\.[0-9]+){0,2})(.[xX*])?$ ]]; then
+  if [[ "${target}" =~ ^([>~^=]|\>\=)?v?([0-9]+(\.[0-9]+){0,2})(.[xX*])?$ ]]; then
     local operator="${BASH_REMATCH[1]}"
     local version="${BASH_REMATCH[2]}"
 
@@ -1258,6 +1258,16 @@ function version_satisfies_target() {
         ;;
     \>) version_gte "${current}" "${version}" && [[ "${current}" != "${version}" ]] ;;
     \>=) version_gte "${current}" "${version}" ;;
+    \^) version_gte "${current}" "${version}" && [[ "${current%%.*}" == "${version%%.*}" ]] ;;
+    \~)
+      if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        version_gte "${current}" "${version}" && [[ "${current%.*}" == "${version%.*}" ]]
+      elif [[ "${version}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+        version_gte "${current}" "${version}" && [[ "${current%.*}" == "${version}" ]]
+      else
+        version_gte "${current}" "${version}" && [[ "${current%%.*}" == "${version}" ]]
+      fi
+      ;;
     esac
   else
     # Complex range, use npx semver for checking

--- a/bin/n
+++ b/bin/n
@@ -1272,7 +1272,7 @@ function version_satisfies_target() {
   else
     # Complex range, use npx semver for checking
     command -v npx &> /dev/null || return 1
-    npx --quiet semver@7 "${current}" -r "${target}" &> /dev/null
+    npm_config_yes=true npx --quiet semver@7 "${current}" -r "${target}" &> /dev/null
   fi
 }
 

--- a/bin/n
+++ b/bin/n
@@ -1335,9 +1335,11 @@ function get_latest_resolved_version() {
   if [[ -z "${g_if_needed_node}" ]]; then
     if is_numeric_version "${version}"; then
       g_if_needed_node="${version}"
-    elif is_lts_codename "${version}" || [[ "${version}" = "lts" ]]; then
+    elif is_lts_codename "${version}"; then
       # Codenames (e.g. "argon") will only if-needed match major rather than latest minor/patch
       g_if_needed_node=$(display_major_version "${g_target_node}")
+    elif [[ "${version}" = "lts" ]]; then
+      g_if_needed_node=">=$(get_latest_lts_lowest_version)"
     else
       # Other strings (e.g. latest, nightly, rc) should never skip updates
       g_if_needed_node=""
@@ -1497,6 +1499,22 @@ function display_remote_versions() {
     | n_grep -E -o '[^v].*'
   return "${PIPESTATUS[0]}"
 }
+
+
+#
+# Synposis: return earliest version of latest LTS release
+#
+get_latest_lts_lowest_version() {
+  display_remote_index | awk -F'\t' '
+      $3 != "-" {
+        if (!lts_name) lts_name = $3
+        if ($3 == lts_name) version = $1
+      }
+      END { print version }
+    ' | n_grep -E -o '[^v].*'
+  return "${PIPESTATUS[0]}"
+}
+
 
 #
 # Synopsis: delete_with_echo target

--- a/bin/n
+++ b/bin/n
@@ -133,11 +133,11 @@ g_active_node=
 g_target_node=
 
 # Like g_target_node, but retained granularity differs based on context
-g_lazy_node=
+g_if_needed_node=
 
 DOWNLOAD=false # set to opt-out of activate (install), and opt-in to download (run, exec)
 CLEANUP=false # remove cached download after install
-LAZY=false # check if current version satisfies requirement before installing
+CHECK_IF_NEEDED=false # check if current version satisfies requirement before installing
 ARCH="${N_ARCH-}"
 SHOW_VERBOSE_LOG="true"
 OFFLINE=false
@@ -413,7 +413,7 @@ Options:
   --cleanup             Remove cached version after install
   -a, --arch            Override system architecture
   --offline             Resolve target version against cached downloads instead of internet lookup
-  --lazy                Skip install if current version already "good enough"
+  --if-needed           Skip install if current version already "good enough"
   --all                 ls-remote displays all matches instead of last 20
   --insecure            Turn off certificate checking for https requests (may be needed from behind a proxy server)
   --use-xz/--no-use-xz  Override automatic detection of xz support and enable/disable use of xz compressed node downloads.
@@ -793,13 +793,11 @@ install() {
   
   local current_version="$(node --version 2>/dev/null)"
   verbose_log "current" "${current_version}"
-  if [[ "$LAZY" == "true" ]]; then
-    if [[ -n "${current_version}" ]]; then
-      verbose_log "lazy" "${g_lazy_node}"
-      if version_satisfies_target "${current_version}" "${g_lazy_node}"; then
-        echo "Current version ${current_version} satisfies requirement ${g_lazy_node}"
-        return 0
-      fi
+  if [[ "$CHECK_IF_NEEDED" == "true" && -n "${current_version}" ]]; then
+    verbose_log "if-needed" "${g_if_needed_node}"
+    if version_satisfies_target "${current_version}" "${g_if_needed_node}"; then
+      echo "Current version ${current_version} satisfies requirement ${g_if_needed_node}"
+      return 0
     fi
   fi
   
@@ -1131,7 +1129,7 @@ function get_file_node_version() {
 
 function get_package_engine_version() {
   g_target_node=
-  g_lazy_node=
+  g_if_needed_node=
   local filepath="$1"
   verbose_log "found" "${filepath}"
   local range
@@ -1144,7 +1142,7 @@ function get_package_engine_version() {
   fi
   verbose_log "read" "${range}"
   [[ -n "${range}" ]] || return 2
-  g_lazy_node="${range}" # Store range before we start replacing numbers with "current"
+  g_if_needed_node="${range}" # Store range before we start replacing numbers with "current"
   if [[ "*" == "${range}" ]]; then
     verbose_log "target" "current"
     g_target_node="current"
@@ -1332,12 +1330,12 @@ function get_latest_resolved_version() {
     g_target_node=$(N_MAX_REMOTE_MATCHES=1 display_remote_versions "$version")
   fi
 
-  if [[ -z "${g_lazy_node}" ]]; then
+  if [[ -z "${g_if_needed_node}" ]]; then
     if ! is_numeric_version "${version}" && [[ "${version}" != "latest" && "${version}" != "current" ]]; then
-      # Codenames (e.g. "argon") will only lazy match major rather than latest minor/patch
-      g_lazy_node=$(display_major_version "${g_target_node}")
+      # Codenames (e.g. "argon") will only if-needed match major rather than latest minor/patch
+      g_if_needed_node=$(display_major_version "${g_target_node}")
     else
-      g_lazy_node="${version}"
+      g_if_needed_node="${version}"
     fi
   fi
 }
@@ -1790,7 +1788,7 @@ while [[ $# -ne 0 ]]; do
     --no-preserve) N_PRESERVE_NPM="" N_PRESERVE_COREPACK="" ;;
     --use-xz) N_USE_XZ="true" ;;
     --no-use-xz) N_USE_XZ="false" ;;
-    --lazy) LAZY="true" ;;
+    --if-needed) CHECK_IF_NEEDED="true" ;;
     --latest) display_remote_versions latest; exit ;;
     --stable) display_remote_versions lts; exit ;; # [sic] old terminology
     --lts) display_remote_versions lts; exit ;;

--- a/test/dockerfiles/Dockerfile-fedora-curl
+++ b/test/dockerfiles/Dockerfile-fedora-curl
@@ -1,3 +1,5 @@
 FROM fedora:latest
 
+RUN dnf install -y libatomic && dnf clean all
+
 CMD ["/bin/bash"]

--- a/test/dockerfiles/Dockerfile-ubuntu-curl
+++ b/test/dockerfiles/Dockerfile-ubuntu-curl
@@ -3,7 +3,7 @@ FROM ubuntu:latest
 # curl
 
 RUN apt-get update \
-&& apt-get install -y curl \
+&& apt-get install -y curl libatomic1 \
 && rm -rf /var/lib/apt/lists/*
 
 CMD ["/bin/bash"]

--- a/test/dockerfiles/Dockerfile-ubuntu-wget
+++ b/test/dockerfiles/Dockerfile-ubuntu-wget
@@ -3,7 +3,7 @@ FROM ubuntu:latest
 # wget
 
 RUN apt-get update \
-&& apt-get install -y wget \
+&& apt-get install -y wget libatomic1 \
 && rm -rf /var/lib/apt/lists/*
 
 CMD ["/bin/bash"]

--- a/test/tests/install-if-needed.bats
+++ b/test/tests/install-if-needed.bats
@@ -460,7 +460,7 @@ function teardown() {
 
   run n --if-needed lts
   assert_success
-  assert_output --partial "if-needed : >=${lts}"
+  assert_output --partial "if-needed : ^${lts}"
   assert_output --partial "satisfies requirement"
 
   output="$(node --version)"
@@ -482,6 +482,20 @@ function teardown() {
   assert_equal "${output}" "v${lts}"
 }
 
+
+@test "n --if-needed lts downgrade" {
+  local lts="$(display_remote_version lts)"
+  
+  n 25.2.0
+  output="$(node --version)"
+  assert_equal "${output}" "v25.2.0"
+
+  run n --if-needed lts
+  assert_success
+
+  output="$(node --version)"
+  assert_equal "${output}" "v${lts}"
+}
 
 @test "n --if-needed without existing node" {
   n --if-needed 4.9.1

--- a/test/tests/install-if-needed.bats
+++ b/test/tests/install-if-needed.bats
@@ -452,19 +452,34 @@ function teardown() {
 
 
 @test "n --if-needed lts match" {
-  local latest="$(display_remote_version lts)"
-  local preinstalled="${latest%%.*}.0.0"
+  local lts="$(get_latest_lts_lowest_version)"
   
-  n "${preinstalled}"
+  n "${lts}"
   output="$(node --version)"
-  assert_equal "${output}" "v${preinstalled}"
+  assert_equal "${output}" "v${lts}"
 
   run n --if-needed lts
   assert_success
+  assert_output --partial "if-needed : >=${lts}"
   assert_output --partial "satisfies requirement"
 
   output="$(node --version)"
-  assert_equal "${output}" "v${preinstalled}"
+  assert_equal "${output}" "v${lts}"
+}
+
+
+@test "n --if-needed lts mismatch" {
+  local lts="$(display_remote_version lts)"
+  
+  n 4.9.1
+  output="$(node --version)"
+  assert_equal "${output}" "v4.9.1"
+
+  run n --if-needed lts
+  assert_success
+
+  output="$(node --version)"
+  assert_equal "${output}" "v${lts}"
 }
 
 

--- a/test/tests/install-if-needed.bats
+++ b/test/tests/install-if-needed.bats
@@ -16,24 +16,24 @@ function teardown() {
 }
 
 
-@test "n --lazy with exact match" {
+@test "n --if-needed with exact match" {
   n 4.9.1
   output="$(node --version)"
   assert_equal "${output}" "v4.9.1"
   
-  # --lazy should skip installation when exact match
-  run n --lazy 4.9.1
+  # --if-needed should skip installation when exact match
+  run n --if-needed 4.9.1
   assert_success
   assert_output --partial "Current version v4.9.1 satisfies requirement 4.9.1"
 }
 
 
-@test "n --lazy with major version match" {
+@test "n --if-needed with major version match" {
   n 4.9.1
   output="$(node --version)"
   assert_equal "${output}" "v4.9.1"
   
-  run n --lazy 4
+  run n --if-needed 4
   assert_success
   assert_output --partial "satisfies requirement"
   
@@ -42,24 +42,24 @@ function teardown() {
 }
 
 
-@test "n --lazy with different major version" {  
+@test "n --if-needed with different major version" {  
   n 4.9.1
   output="$(node --version)"
   assert_equal "${output}" "v4.9.1"
   
-  # --lazy should NOT skip when major versions differ
-  n --lazy 6
+  # --if-needed should NOT skip when major versions differ
+  n --if-needed 6
   output="$(node --version)"
   assert_equal "${output}" "v6.17.1"
 }
 
 
-@test "n --lazy with major.minor version match" {
+@test "n --if-needed with major.minor version match" {
   n 4.9.0
   output="$(node --version)"
   assert_equal "${output}" "v4.9.0"
   
-  run n --lazy 4.9
+  run n --if-needed 4.9
   assert_success
   assert_output --partial "satisfies requirement"
   
@@ -68,29 +68,29 @@ function teardown() {
 }
 
 
-@test "n --lazy with major.minor version upgrade" {
+@test "n --if-needed with major.minor version upgrade" {
   n 4.8.0
   output="$(node --version)"
   assert_equal "${output}" "v4.8.0"
   
-  n --lazy 4.9
+  n --if-needed 4.9
   output="$(node --version)"
   assert_equal "${output}" "v4.9.1"
 }
 
 
-@test "n --lazy with major.minor version downgrade" {
+@test "n --if-needed with major.minor version downgrade" {
   n 4.9.1
   output="$(node --version)"
   assert_equal "${output}" "v4.9.1"
   
-  n --lazy 4.8
+  n --if-needed 4.8
   output="$(node --version)"
   assert_equal "${output}" "v4.8.7"
 }
 
 
-@test "n --lazy with auto major version" {
+@test "n --if-needed with auto major version" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo "4" > .node-version
@@ -99,7 +99,7 @@ function teardown() {
   output="$(node --version)"
   assert_equal "${output}" "v4.8.0"
   
-  run n --lazy auto
+  run n --if-needed auto
   assert_success
   assert_output --partial "satisfies requirement"
   
@@ -108,7 +108,7 @@ function teardown() {
 }
 
 
-@test "n --lazy with codename" {
+@test "n --if-needed with codename" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo "4" > .node-version
@@ -117,7 +117,7 @@ function teardown() {
   output="$(node --version)"
   assert_equal "${output}" "v4.8.0"
   
-  run n --lazy argon
+  run n --if-needed argon
   assert_success
   assert_output --partial "satisfies requirement"
   
@@ -126,7 +126,7 @@ function teardown() {
 }
 
 
-@test "n --lazy with auto major.minor version" {
+@test "n --if-needed with auto major.minor version" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo "4.8" > .node-version
@@ -135,7 +135,7 @@ function teardown() {
   output="$(node --version)"
   assert_equal "${output}" "v4.8.0"
   
-  run n --lazy auto
+  run n --if-needed auto
   assert_success
   assert_output --partial "satisfies requirement"
   
@@ -144,7 +144,7 @@ function teardown() {
 }
 
 
-@test "n --lazy with engine range match" {
+@test "n --if-needed with engine range match" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo '{"engines": {"node": ">=4"}}' > package.json
@@ -153,7 +153,7 @@ function teardown() {
   output="$(node --version)"
   assert_equal "${output}" "v4.8.0"
   
-  run n --lazy engine
+  run n --if-needed engine
   assert_success
   assert_output --partial "satisfies requirement"
   
@@ -162,7 +162,7 @@ function teardown() {
 }
 
 
-@test "n --lazy with engine range mismatch" {
+@test "n --if-needed with engine range mismatch" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo '{"engines": {"node": ">=8 <12"}}' > package.json
@@ -171,7 +171,7 @@ function teardown() {
   output="$(node --version)"
   assert_equal "${output}" "v8.16.0"
   
-  run n --lazy engine
+  run n --if-needed engine
   assert_success
   assert_output --partial "satisfies requirement"
   
@@ -180,7 +180,7 @@ function teardown() {
 }
 
 
-@test "n --lazy with engine || match" {
+@test "n --if-needed with engine || match" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo '{"engines": {"node": "8 || 10"}}' > package.json
@@ -189,7 +189,7 @@ function teardown() {
   output="$(node --version)"
   assert_equal "${output}" "v8.16.0"
   
-  run n --lazy engine
+  run n --if-needed engine
   assert_success
   assert_output --partial "satisfies requirement"
   
@@ -198,7 +198,7 @@ function teardown() {
 }
 
 
-@test "n --lazy with engine || mismatch" {
+@test "n --if-needed with engine || mismatch" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo '{"engines": {"node": "10 || 12"}}' > package.json
@@ -207,7 +207,7 @@ function teardown() {
   output="$(node --version)"
   assert_equal "${output}" "v8.16.0"
   
-  run n --lazy engine
+  run n --if-needed engine
   assert_success
   
   output="$(node --version)"
@@ -215,7 +215,7 @@ function teardown() {
 }
 
 
-@test "n --lazy with engine ~ match" {
+@test "n --if-needed with engine ~ match" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo '{"engines": {"node": "~8.2.0"}}' > package.json
@@ -224,7 +224,7 @@ function teardown() {
   output="$(node --version)"
   assert_equal "${output}" "v8.2.1"
   
-  run n --lazy engine
+  run n --if-needed engine
   assert_success
   assert_output --partial "satisfies requirement"
   
@@ -233,7 +233,7 @@ function teardown() {
 }
 
 
-@test "n --lazy with engine ~ mismatch" {
+@test "n --if-needed with engine ~ mismatch" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo '{"engines": {"node": "~8.2.1"}}' > package.json
@@ -242,7 +242,7 @@ function teardown() {
   output="$(node --version)"
   assert_equal "${output}" "v8.2.0"
   
-  run n --lazy engine
+  run n --if-needed engine
   assert_success
   
   output="$(node --version)"
@@ -250,7 +250,7 @@ function teardown() {
 }
 
 
-@test "n --lazy with engine ^ match" {
+@test "n --if-needed with engine ^ match" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo '{"engines": {"node": "^8.1.0"}}' > package.json
@@ -259,7 +259,7 @@ function teardown() {
   output="$(node --version)"
   assert_equal "${output}" "v8.2.0"
   
-  run n --lazy engine
+  run n --if-needed engine
   assert_success
   assert_output --partial "satisfies requirement"
   
@@ -268,7 +268,7 @@ function teardown() {
 }
 
 
-@test "n --lazy with engine ^ mismatch" {
+@test "n --if-needed with engine ^ mismatch" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo '{"engines": {"node": "^8.3.0"}}' > package.json
@@ -277,7 +277,7 @@ function teardown() {
   output="$(node --version)"
   assert_equal "${output}" "v8.2.0"
   
-  run n --lazy engine
+  run n --if-needed engine
   assert_success
   
   output="$(node --version)"
@@ -285,8 +285,8 @@ function teardown() {
 }
 
 
-@test "n --lazy without existing node" {
-  n --lazy 4.9.1
+@test "n --if-needed without existing node" {
+  n --if-needed 4.9.1
   output="$(node --version)"
   assert_equal "${output}" "v4.9.1"
 }

--- a/test/tests/install-if-needed.bats
+++ b/test/tests/install-if-needed.bats
@@ -108,7 +108,7 @@ function teardown() {
 }
 
 
-@test "n --if-needed with codename" {
+@test "n --if-needed with codename match" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo "4" > .node-version
@@ -123,6 +123,16 @@ function teardown() {
   
   output="$(node --version)"
   assert_equal "${output}" "v4.8.0"
+}
+
+@test "n --if-needed with codename mismatch" {
+  n 4.8.0
+  output="$(node --version)"
+  assert_equal "${output}" "v4.8.0"
+  
+  n --if-needed boron
+  output="$(node --version)"
+  assert_equal "${output}" "v6.17.1"
 }
 
 
@@ -422,6 +432,39 @@ function teardown() {
   
   output="$(node --version)"
   assert_equal "${output}" "v10.24.1"
+}
+
+
+@test "n --if-needed latest always update" {
+  local latest="$(display_remote_version latest)"
+  local preinstalled="${latest%%.*}.0.0"
+  
+  n "${preinstalled}"
+  output="$(node --version)"
+  assert_equal "${output}" "v${preinstalled}"
+  
+  run n --if-needed latest
+  assert_success
+
+  output="$(node --version)"
+  assert_equal "${output}" "v${latest}"
+}
+
+
+@test "n --if-needed lts match" {
+  local latest="$(display_remote_version lts)"
+  local preinstalled="${latest%%.*}.0.0"
+  
+  n "${preinstalled}"
+  output="$(node --version)"
+  assert_equal "${output}" "v${preinstalled}"
+
+  run n --if-needed lts
+  assert_success
+  assert_output --partial "satisfies requirement"
+
+  output="$(node --version)"
+  assert_equal "${output}" "v${preinstalled}"
 }
 
 

--- a/test/tests/install-if-needed.bats
+++ b/test/tests/install-if-needed.bats
@@ -215,7 +215,7 @@ function teardown() {
 }
 
 
-@test "n --if-needed with engine ~ match" {
+@test "n --if-needed with engine ~x.y.z match" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo '{"engines": {"node": "~8.2.0"}}' > package.json
@@ -233,7 +233,7 @@ function teardown() {
 }
 
 
-@test "n --if-needed with engine ~ mismatch" {
+@test "n --if-needed with engine ~x.y.z mismatch" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo '{"engines": {"node": "~8.2.1"}}' > package.json
@@ -250,7 +250,77 @@ function teardown() {
 }
 
 
-@test "n --if-needed with engine ^ match" {
+@test "n --if-needed with engine ~x.y match" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": "~8.2"}}' > package.json
+  
+  n 8.2.1
+  output="$(node --version)"
+  assert_equal "${output}" "v8.2.1"
+  
+  run n --if-needed engine
+  assert_success
+  assert_output --partial "satisfies requirement"
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v8.2.1"
+}
+
+
+@test "n --if-needed with engine ~x.y minor mismatch" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": "~8.3"}}' > package.json
+  
+  n 8.2.1
+  output="$(node --version)"
+  assert_equal "${output}" "v8.2.1"
+  
+  run n --if-needed engine
+  assert_success
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v8.3.0"
+}
+
+
+@test "n --if-needed with engine ~x match" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": "~8"}}' > package.json
+  
+  n 8.2.1
+  output="$(node --version)"
+  assert_equal "${output}" "v8.2.1"
+  
+  run n --if-needed engine
+  assert_success
+  assert_output --partial "satisfies requirement"
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v8.2.1"
+}
+
+
+@test "n --if-needed with engine ~x major mismatch" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": "~10"}}' > package.json
+  
+  n 8.2.1
+  output="$(node --version)"
+  assert_equal "${output}" "v8.2.1"
+  
+  run n --if-needed engine
+  assert_success
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v10.24.1"
+}
+
+
+@test "n --if-needed with engine ^x.y.z match" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo '{"engines": {"node": "^8.1.0"}}' > package.json
@@ -268,7 +338,7 @@ function teardown() {
 }
 
 
-@test "n --if-needed with engine ^ mismatch" {
+@test "n --if-needed with engine ^x.y.z mismatch" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo '{"engines": {"node": "^8.3.0"}}' > package.json
@@ -282,6 +352,76 @@ function teardown() {
   
   output="$(node --version)"
   assert_equal "${output}" "v8.17.0"
+}
+
+
+@test "n --if-needed with engine ^x.y match" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": "^8.1"}}' > package.json
+  
+  n 8.16.0
+  output="$(node --version)"
+  assert_equal "${output}" "v8.16.0"
+  
+  run n --if-needed engine
+  assert_success
+  assert_output --partial "satisfies requirement"
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v8.16.0"
+}
+
+
+@test "n --if-needed with engine ^x.y major mismatch" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": "^10.1"}}' > package.json
+  
+  n 8.16.0
+  output="$(node --version)"
+  assert_equal "${output}" "v8.16.0"
+  
+  run n --if-needed engine
+  assert_success
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v10.24.1"
+}
+
+
+@test "n --if-needed with engine ^x match" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": "^8"}}' > package.json
+  
+  n 8.16.0
+  output="$(node --version)"
+  assert_equal "${output}" "v8.16.0"
+  
+  run n --if-needed engine
+  assert_success
+  assert_output --partial "satisfies requirement"
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v8.16.0"
+}
+
+
+@test "n --if-needed with engine ^x major mismatch" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": "^10"}}' > package.json
+  
+  n 8.16.0
+  output="$(node --version)"
+  assert_equal "${output}" "v8.16.0"
+  
+  run n --if-needed engine
+  assert_success
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v10.24.1"
 }
 
 

--- a/test/tests/install-lazy.bats
+++ b/test/tests/install-lazy.bats
@@ -145,7 +145,7 @@ function teardown() {
 }
 
 
-@test "n --lazy with engine range satisfied" {
+@test "n --lazy with engine range match" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo '{"engines": {"node": ">=4"}}' > package.json
@@ -163,7 +163,25 @@ function teardown() {
 }
 
 
-@test "n --lazy with engine or" {
+@test "n --lazy with engine range mismatch" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": ">=8 <12"}}' > package.json
+  
+  n 8.16.0
+  output="$(node --version)"
+  assert_equal "${output}" "v8.16.0"
+  
+  run n --lazy engine
+  assert_success
+  assert_output --partial "satisfies requirement"
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v8.16.0"
+}
+
+
+@test "n --lazy with engine || match" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo '{"engines": {"node": "8 || 10"}}' > package.json
@@ -181,10 +199,10 @@ function teardown() {
 }
 
 
-@test "n --lazy with engine range" {
+@test "n --lazy with engine || mismatch" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
-  echo '{"engines": {"node": ">=8 <12"}}' > package.json
+  echo '{"engines": {"node": "10 || 12"}}' > package.json
   
   n 8.16.0
   output="$(node --version)"
@@ -192,10 +210,9 @@ function teardown() {
   
   run n --lazy engine
   assert_success
-  assert_output --partial "satisfies requirement"
   
   output="$(node --version)"
-  assert_equal "${output}" "v8.16.0"
+  assert_equal "${output}" "v12.22.12"
 }
 
 

--- a/test/tests/install-lazy.bats
+++ b/test/tests/install-lazy.bats
@@ -15,6 +15,7 @@ function teardown() {
   rm -rf "${TMP_PREFIX_DIR}"
 }
 
+
 @test "n --lazy with exact match" {
   n 4.9.1
   output="$(node --version)"
@@ -219,5 +220,3 @@ function teardown() {
   output="$(node --version)"
   assert_equal "${output}" "v4.9.1"
 }
-
-# ToDo: --arch

--- a/test/tests/install-lazy.bats
+++ b/test/tests/install-lazy.bats
@@ -1,0 +1,190 @@
+#!/usr/bin/env bats
+
+load shared-functions
+load '../../node_modules/bats-support/load'
+load '../../node_modules/bats-assert/load'
+
+
+function setup() {
+  unset_n_env
+  setup_tmp_prefix
+}
+
+
+function teardown() {
+  rm -rf "${TMP_PREFIX_DIR}"
+}
+
+# bats file_tags=foobar
+
+@test "n --lazy with exact match" {
+  n 4.9.1
+  output="$(node --version)"
+  assert_equal "${output}" "v4.9.1"
+  
+  # --lazy should skip installation when exact match
+  run n --lazy 4.9.1
+  assert_success
+  assert_output --partial "Current version v4.9.1 satisfies requirement 4.9.1"
+}
+
+
+@test "n --lazy with major version match" {
+  n 4.9.1
+  output="$(node --version)"
+  assert_equal "${output}" "v4.9.1"
+  
+  run n --lazy 4
+  assert_success
+  assert_output --partial "satisfies requirement"
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v4.9.1"
+}
+
+
+@test "n --lazy with different major version" {  
+  n 4.9.1
+  output="$(node --version)"
+  assert_equal "${output}" "v4.9.1"
+  
+  # --lazy should NOT skip when major versions differ
+  n --lazy 6
+  output="$(node --version)"
+  assert_equal "${output}" "v6.17.1"
+}
+
+
+@test "n --lazy with major.minor version match" {
+  n 4.9.0
+  output="$(node --version)"
+  assert_equal "${output}" "v4.9.0"
+  
+  run n --lazy 4.9
+  assert_success
+  assert_output --partial "satisfies requirement"
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v4.9.0"
+}
+
+
+@test "n --lazy with major.minor version upgrade" {
+  n 4.8.0
+  output="$(node --version)"
+  assert_equal "${output}" "v4.8.0"
+  
+  n --lazy 4.9
+  output="$(node --version)"
+  assert_equal "${output}" "v4.9.1"
+}
+
+
+@test "n --lazy with major.minor version downgrade" {
+  n 4.9.1
+  output="$(node --version)"
+  assert_equal "${output}" "v4.9.1"
+  
+  n --lazy 4.8
+  output="$(node --version)"
+  assert_equal "${output}" "v4.8.7"
+}
+
+
+@test "n --lazy with auto major version" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo "4" > .node-version
+  
+  n 4.8.0
+  output="$(node --version)"
+  assert_equal "${output}" "v4.8.0"
+  
+  run n --lazy auto
+  assert_success
+  assert_output --partial "satisfies requirement"
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v4.8.0"
+}
+
+
+@test "n --lazy with codename" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo "4" > .node-version
+  
+  n 4.8.0
+  output="$(node --version)"
+  assert_equal "${output}" "v4.8.0"
+  
+  run n --lazy argon
+  assert_success
+  assert_output --partial "satisfies requirement"
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v4.8.0"
+}
+
+
+@test "n --lazy with auto major.minor version" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo "4.8" > .node-version
+  
+  n 4.8.0
+  output="$(node --version)"
+  assert_equal "${output}" "v4.8.0"
+  
+  run n --lazy auto
+  assert_success
+  assert_output --partial "satisfies requirement"
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v4.8.0"
+}
+
+
+@test "n --lazy with engine range satisfied" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": ">=4"}}' > package.json
+  
+  n 4.8.0
+  output="$(node --version)"
+  assert_equal "${output}" "v4.8.0"
+  
+  run n --lazy engine
+  assert_success
+  assert_output --partial "satisfies requirement"
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v4.8.0"
+}
+
+@test "n --lazy with complex engine syntax" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": "8 || 10"}}' > package.json
+  
+  n 8.16.0
+  output="$(node --version)"
+  assert_equal "${output}" "v8.16.0"
+  
+  run n --lazy engine
+  assert_success
+  assert_output --partial "satisfies requirement"
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v8.16.0"
+}
+
+
+@test "n --lazy without existing node" {
+  n --lazy 4.9.1
+  output="$(node --version)"
+  assert_equal "${output}" "v4.9.1"
+}
+# bats file_tags=
+
+# ToDo: --arch

--- a/test/tests/install-lazy.bats
+++ b/test/tests/install-lazy.bats
@@ -215,6 +215,76 @@ function teardown() {
 }
 
 
+@test "n --lazy with engine ~ match" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": "~8.2.0"}}' > package.json
+  
+  n 8.2.1
+  output="$(node --version)"
+  assert_equal "${output}" "v8.2.1"
+  
+  run n --lazy engine
+  assert_success
+  assert_output --partial "satisfies requirement"
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v8.2.1"
+}
+
+
+@test "n --lazy with engine ~ mismatch" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": "~8.2.1"}}' > package.json
+  
+  n 8.2.0
+  output="$(node --version)"
+  assert_equal "${output}" "v8.2.0"
+  
+  run n --lazy engine
+  assert_success
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v8.2.1"
+}
+
+
+@test "n --lazy with engine ^ match" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": "^8.1.0"}}' > package.json
+  
+  n 8.2.0
+  output="$(node --version)"
+  assert_equal "${output}" "v8.2.0"
+  
+  run n --lazy engine
+  assert_success
+  assert_output --partial "satisfies requirement"
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v8.2.0"
+}
+
+
+@test "n --lazy with engine ^ mismatch" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": "^8.3.0"}}' > package.json
+  
+  n 8.2.0
+  output="$(node --version)"
+  assert_equal "${output}" "v8.2.0"
+  
+  run n --lazy engine
+  assert_success
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v8.17.0"
+}
+
+
 @test "n --lazy without existing node" {
   n --lazy 4.9.1
   output="$(node --version)"

--- a/test/tests/install-lazy.bats
+++ b/test/tests/install-lazy.bats
@@ -162,10 +162,29 @@ function teardown() {
   assert_equal "${output}" "v4.8.0"
 }
 
-@test "n --lazy with complex engine syntax" {
+
+@test "n --lazy with engine or" {
   mkdir -p "${TMP_PREFIX_DIR}/project"
   cd "${TMP_PREFIX_DIR}/project"
   echo '{"engines": {"node": "8 || 10"}}' > package.json
+  
+  n 8.16.0
+  output="$(node --version)"
+  assert_equal "${output}" "v8.16.0"
+  
+  run n --lazy engine
+  assert_success
+  assert_output --partial "satisfies requirement"
+  
+  output="$(node --version)"
+  assert_equal "${output}" "v8.16.0"
+}
+
+
+@test "n --lazy with engine range" {
+  mkdir -p "${TMP_PREFIX_DIR}/project"
+  cd "${TMP_PREFIX_DIR}/project"
+  echo '{"engines": {"node": ">=8 <12"}}' > package.json
   
   n 8.16.0
   output="$(node --version)"

--- a/test/tests/install-lazy.bats
+++ b/test/tests/install-lazy.bats
@@ -15,8 +15,6 @@ function teardown() {
   rm -rf "${TMP_PREFIX_DIR}"
 }
 
-# bats file_tags=foobar
-
 @test "n --lazy with exact match" {
   n 4.9.1
   output="$(node --version)"
@@ -221,6 +219,5 @@ function teardown() {
   output="$(node --version)"
   assert_equal "${output}" "v4.9.1"
 }
-# bats file_tags=
 
 # ToDo: --arch

--- a/test/tests/shared-functions.bash
+++ b/test/tests/shared-functions.bash
@@ -101,3 +101,31 @@ function display_remote_version() {
     | awk "NR==1" \
     | grep -E -o '[^v].*'
 }
+
+
+# get_latest_lts_lowest_version
+# Return the lowest minor version of the latest LTS major version.
+# Return version number, without leading v.
+
+function get_latest_lts_lowest_version() {
+  local fetch
+  if command -v curl &> /dev/null; then
+    fetch="curl --silent --location --fail --compressed"
+  else
+    fetch="wget -q -O- --no-check-certificate"
+  fi
+
+  local mirror="${N_NODE_MIRROR:-https://nodejs.org/dist}"
+  
+  ${fetch} "${mirror}/index.tab" \
+    | tail -n +2 \
+    | cut -f 1,10 \
+    | awk -F'\t' '
+      $2 != "-" {
+        if (!lts_name) lts_name = $2
+        if ($2 == lts_name) version = $1
+      }
+      END { print version }
+    ' \
+    | grep -E -o '[^v].*'
+}


### PR DESCRIPTION
# Pull Request

## Problem

When using `n` to install Node.js versions without an exact version match (e.g., `n 18`, `n lts`, `n auto`), the tool always jumps to the latest version even if the currently active version technically satisfies the requirement. This is inefficient in scenarios like CI/CD pipelines where the existing version may be "good enough". 

If a custom pipeline docker image has `22.21.0` preinstalled, I don't need every deployment (in the case of engines `22`) to update to `22.21.1`. However, I do want `n auto` to support repositories that require alternate Node versions. 

Additionally, developers often only specify a minimum supported release (e.g `>=20`) but then a new Node release (e.g. 25) comes out and breaks everything. For those situations, a lazy update procedure would be convenient such that we can delay fixing Node 25 issues until we're ready to switch to Node 26 LTS.

## Solution

Added a `--lazy` flag that checks if the currently active Node.js version satisfies the requested version or range before installing. If the current version is "good enough", the installation is skipped. Using targets `latest` or `current` will ignore `--lazy`.

The lazy check supports:
- Major.minor ranges (e.g. `4.9` matches any `4.9.x`)
- Major version ranges (e.g. `4` matches any `4.x.x`)
- Release codename as major version ranges (e.g. `argon` matches `4.x.x`)
- Semver operators (e.g. `>=`, `>`, `~`, `^`, `=`)
- Complex ranges via `npx semver` (e.g. `>=8 <12`, `8 || 10`)

## ChangeLog

Added `--lazy` flag to skip installation if current Node.js version satisfies the requested version or range
