### PR TITLE
Remove Node.js support aliases fron documentation, except for lts_latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Numeric version numbers can be complete or incomplete, with an optional leading 
 
 There are labels for two especially useful versions:
 
-- `lts`: newest Long Term Support official release
+- `lts`, `lts_latest`: newest Long Term Support official release
 - `latest`, `current`: newest official release
   
 There is an `auto` label to read the target version from a file in the current directory, or any parent directory. `n` looks for in order:
@@ -149,10 +149,6 @@ The `engine` label looks for a `package.json` file and reads the `engines` field
 There is support for the named release streams:
 
 - `argon`, `boron`, `carbon`: codenames for LTS release streams
-
-These Node.js support aliases may be used, although simply resolve to the latest matching version:
-
-- `active`, `lts_active`, `lts_latest`, `lts`, `current`, `supported`
 
 The last version form is for specifying [other releases](https://nodejs.org/download) available using the name of the remote download folder optionally followed by the complete or incomplete version.
 

--- a/bin/n
+++ b/bin/n
@@ -317,7 +317,12 @@ function is_node_support_version() {
 
 #
 # Synopsis: display_latest_node_support_alias version
-# Map aliases onto existing n aliases, current and lts
+# Map aliases onto existing n aliases, current and lts.
+#
+# Since we resolve to a single version these are of limited use. Now only
+# mention lts_latest in README and help, since that one is used a bit in the wild.
+# Caveat: lts_active may be incorrect across node releases when
+# there isn't actually an active version for a brief period.
 #
 
 function display_latest_node_support_alias() {
@@ -409,10 +414,8 @@ Options:
 Aliases:
 
   install: i
-  latest: current
   ls: list
   lsr: ls-remote
-  lts: stable
   rm: -
   run: use, as
   which: bin
@@ -424,12 +427,11 @@ Versions:
   and other downloadable releases by <remote-folder>/<version>
 
     4.9.1, 8, v6.1    Numeric versions
-    lts               Newest Long Term Support official release
+    lts, lts_latest   Newest Long Term Support official release
     latest, current   Newest official release
     auto              Read version from file: .n-node-version, .node-version, .nvmrc, or package.json
     engine            Read version from package.json
     boron, carbon     Codenames for release streams
-    lts_latest        Node.js support aliases
 
     and nightly, rc/10 et al
 
@@ -1739,9 +1741,6 @@ else
     doctor) show_diagnostics; exit ;;
     rm|-) shift; remove_versions "$@"; exit ;;
     prune) prune_cache; exit ;;
-    latest) install latest; exit ;;
-    stable) install stable; exit ;;
-    lts) install lts; exit ;;
     ls|list) display_versions_paths; exit ;;
     lsr|ls-remote|list-remote) shift; display_remote_versions "$1"; exit ;;
     uninstall) uninstall_installed; exit ;;


### PR DESCRIPTION
The Node.js support labels do not add much to `n` since they just resolve to `lts` and `current`. The active related labels are not accurate across node releases when there may not be an active match.

`lts_latest` has been picked up and used in some documentation, so people did like that one.

Remove the other aliases from README and help. Soft-deprecated.

While making changes, I noticed that `lts` and `latest` and `stable` were being parsed as "commands". This may have been necessary in past, but now redundant as they are recognised as versions everywhere. Deleted. 