### PR TITLE
Add libatomic to containers for node 25

### DIFF
--- a/test/dockerfiles/Dockerfile-fedora-curl
+++ b/test/dockerfiles/Dockerfile-fedora-curl
@@ -1,3 +1,7 @@
 FROM fedora:latest
 
+# (libatomic1 currently needed for node 25)
+RUN dnf install -y libatomic \
+&& dnf clean all
+
 CMD ["/bin/bash"]

--- a/test/dockerfiles/Dockerfile-ubuntu-curl
+++ b/test/dockerfiles/Dockerfile-ubuntu-curl
@@ -1,9 +1,10 @@
 FROM ubuntu:latest
 
 # curl
+# (libatomic1 currently needed for node 25)
 
 RUN apt-get update \
-&& apt-get install -y curl \
+&& apt-get install -y curl libatomic1 \
 && rm -rf /var/lib/apt/lists/*
 
 CMD ["/bin/bash"]

--- a/test/dockerfiles/Dockerfile-ubuntu-wget
+++ b/test/dockerfiles/Dockerfile-ubuntu-wget
@@ -1,9 +1,10 @@
 FROM ubuntu:latest
 
 # wget
+# (libatomic1 currently needed for node 25)
 
 RUN apt-get update \
-&& apt-get install -y wget \
+&& apt-get install -y wget libatomic1 \
 && rm -rf /var/lib/apt/lists/*
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
# Pull Request

## Problem

node 25 currently requires install of libatomic1 in some environments, including Ubuntu and Fedora used in tests.

https://github.com/nodejs/node/issues/60790

## Solution

Add libatomic1 in dockerfiles.

Changes copied from #842 and @sigJoe added as a co-author here.

https://github.com/tj/n/pull/842#issuecomment-3481212981

## ChangeLog

- add `libatomic1` to containers for node 25