### PR TITLE
devEngines support

### DIFF
--- a/bin/n
+++ b/bin/n
@@ -430,7 +430,7 @@ Versions:
     lts, lts_latest   Newest Long Term Support official release
     latest, current   Newest official release
     auto              Read version from file: .n-node-version, .node-version, .nvmrc, or package.json
-    engine            Read version from package.json
+    engine            Read version from package.json (devEngines or engines field)
     boron, carbon     Codenames for release streams
 
     and nightly, rc/10 et al
@@ -1111,10 +1111,38 @@ function get_package_engine_version() {
   local filepath="$1"
   verbose_log "found" "${filepath}"
   local range
+  # Look for a target version in devEngines.runtime for node, and engines.node.
   if command -v jq &> /dev/null; then
-    range="$(jq -r '.engines.node // ""' < "${filepath}")"
+    range="$(jq -r '
+      .devEngines.runtime as $r
+      | (
+          if $r == null then empty
+          elif ($r | type) == "array" then
+            first($r[] | select(.name == "node" and .version != null) | .version)
+          elif $r.name == "node" and $r.version != null then
+            $r.version
+          else
+            empty
+          end
+        ) // .engines.node // ""
+    ' "${filepath}")"
   elif command -v node &> /dev/null; then
-    range="$(node -e "package = require('${filepath}'); if (package && package.engines && package.engines.node) console.log(package.engines.node)")"
+    # Using syntax that works back to node 0.12.18
+    range="$(node -e "
+      const fs = require('fs');
+      const package = JSON.parse(fs.readFileSync('${filepath}', 'utf8'));
+      const runtime = package.devEngines && package.devEngines.runtime;
+      const runtimes = Array.isArray(runtime) ? runtime : runtime ? [runtime] : [];
+      var found;
+      for (var i = 0; i < runtimes.length; i++) {
+        if (runtimes[i].name === 'node' && runtimes[i].version != null) {
+          found = runtimes[i];
+          break;
+        }
+      }
+      const range = (found && found.version) || (package.engines && package.engines.node);
+      if (range) console.log(range);
+    ")"
   else
     abort "either jq or an active version of node is required to read 'engines' from package.json"
   fi
@@ -1144,8 +1172,9 @@ function get_package_engine_version() {
     local version_per_line="$(n lsr --all)"
     local versions_one_line=$(echo "${version_per_line}" | tr '\n' ' ')
     # Using semver@7 so works with older versions of node.
+    # The "env -C /" is to avoid npx being restricted by devEngines, assume no package.json in root.
     # shellcheck disable=SC2086
-    version=$(npm_config_yes=true npx --quiet semver@7 -r "${range}" ${versions_one_line} | tail -n 1)
+    version=$(env -C / npm_config_yes=true npx --quiet semver@7 -r "${range}" ${versions_one_line} | tail -n 1)
   fi
   g_target_node="${version}"
 }
@@ -1194,7 +1223,7 @@ function get_engine_version() {
     break
   done
   [[ -n "${parent}" ]] || abort "${error_message}"
-  [[ -n "${g_target_node}" ]] || abort "did not find supported version of node in 'engines' field of package.json"
+  [[ -n "${g_target_node}" ]] || abort "did not find supported version of node in package.json"
 }
 
 #

--- a/bin/n
+++ b/bin/n
@@ -1127,7 +1127,7 @@ function get_package_engine_version() {
         ) // .engines.node // ""
     ' "${filepath}")"
   elif command -v node &> /dev/null; then
-    # Using syntax that works back to node 0.12.18
+    # Using javascript syntax that works back to node 0.12.18
     range="$(node -e "
       const fs = require('fs');
       const package = JSON.parse(fs.readFileSync('${filepath}', 'utf8'));

--- a/test/dockerfiles/Dockerfile-ubuntu-wget
+++ b/test/dockerfiles/Dockerfile-ubuntu-wget
@@ -2,9 +2,10 @@ FROM ubuntu:latest
 
 # wget
 # (libatomic1 currently needed for node 25)
+# add jq so tested in one of the containers
 
 RUN apt-get update \
-&& apt-get install -y wget libatomic1 \
+&& apt-get install -y wget libatomic1 jq \
 && rm -rf /var/lib/apt/lists/*
 
 CMD ["/bin/bash"]

--- a/test/tests.md
+++ b/test/tests.md
@@ -2,14 +2,6 @@
 
 Automated tests for `n`.
 
-## Setup
-
-Optional proxy using mitmproxy:
-
-    # using homebrew (Mac) to install mitmproxy
-    brew install mitmproxy
-
-
 ## Running Tests
 
 Run all the tests across a range of containers and on the host system:
@@ -34,9 +26,10 @@ Using `docker compose` in addition to `docker` for convenient mounting of `n` sc
 
 `bats` is being mounted directly out of `node_modules` into the container as a manual install based on its own install script. This is a bit of a hack, but avoids needing to install `git` or `npm` for a full remote install of `bats`, and means everything on the same version of `bats`.
 
-The containers each have:
-
-* either curl or wget (or both) installed
+Container test coverage, see [run-all-tests](./bin/run-all-tests)
+- `fedora-curl` has curl installed, and does not have jq installed
+- `ubuntu-wget` has wget and jq installed, and does not have curl installed
+- macOS host (if running on macOS!) has curl and jq installed by default
 
 Using `docker compose` to run the container adds:
 

--- a/test/tests/version-auto-priority.bats
+++ b/test/tests/version-auto-priority.bats
@@ -61,7 +61,25 @@ function setup() {
   assert_equal "${output}" "8.3.0"
 }
 
-@test ".package.json last" {
+@test ".package.json devengine fourth with auto" {
+  cd "${MY_DIR}"
+  echo '{ "devEngines" : { "runtime" : { "name": "node", "version": "8.4.0" } } }' > package.json
+  echo '{ "engines" : { "node" : "v8.2.0" } }' >> package.json
+
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "8.4.0"
+}
+
+@test ".package.json devengine first with engine" {
+  cd "${MY_DIR}"
+  echo '{ "engines" : { "node" : "v8.2.0" } }' > package.json
+  echo '{ "devEngines" : { "runtime" : { "name": "node", "version": "8.4.0" } } }' > package.json
+
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION engine)"
+  assert_equal "${output}" "8.4.0"
+}
+
+@test ".package.json engines last " {
   cd "${MY_DIR}"
   echo '{ "engines" : { "node" : "v8.4.0" } }' > package.json
 

--- a/test/tests/version-resolve-auto-engine.bats
+++ b/test/tests/version-resolve-auto-engine.bats
@@ -182,3 +182,36 @@ function write_engine() {
   output="$(https_proxy= n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.11.4"
 }
+
+@test "auto (devengines) object, 8.9.0" {
+  cd "${MY_DIR}"
+  echo '{ "devEngines" : { "runtime" : { "name": "node", "version": "8.9.0" } } }' > package.json
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "8.9.0"
+}
+
+@test "auto (devengines) array, 8.9.0" {
+  cd "${MY_DIR}"
+  echo '{ "devEngines" : { "runtime" : [{ "name": "bun", "version": "1.2.3" }, { "name": "node", "version": "8.9.0" }] } }' > package.json
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "8.9.0"
+}
+
+@test "engine (devengines, semver), <8.12" {
+  cd "${MY_DIR}"
+  echo '{ "devEngines" : { "runtime" : { "name": "node", "version": "<8.12" } } }' > package.json
+  # newer versions of npx not liking proxy as used in tests
+  output="$(https_proxy= n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION engine)"
+  assert_equal "${output}" "8.11.4"
+}
+
+@test "auto mismatch devengines match engines" {
+  cd "${MY_DIR}"
+  write_engine "8.9.1"
+  echo '{ "devEngines" : { "runtime" : { "name": "bun", "version": "1.2.3" } } }' >> package.json
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  assert_equal "${output}" "8.9.1"
+}
+
+# Test ideas
+# devengines wins over engines

--- a/test/tests/version-resolve-auto-engine.bats
+++ b/test/tests/version-resolve-auto-engine.bats
@@ -7,6 +7,7 @@ load '../../node_modules/bats-assert/load'
 
 # auto
 # engine is a label too! These tests mostly use auto as first available only through auto.
+# Most tests using engines in package.json, devEngines support added later.
 
 function setup_file() {
   unset_n_env
@@ -28,7 +29,7 @@ function setup() {
   rm -f "${MY_DIR}/package.json"
 }
 
-function write_engine() {
+function write_engines() {
   echo '{ "engines" : { "node" : "'"$1"'" } }' > package.json
 }
 
@@ -38,35 +39,35 @@ function write_engine() {
 
 @test "auto engine, 8.9.0" {
   cd "${MY_DIR}"
-  write_engine "8.9.0"
+  write_engines "8.9.0"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.9.0"
 }
 
 @test "auto engine, v8.9.1" {
   cd "${MY_DIR}"
-  write_engine "v8.9.1"
+  write_engines "v8.9.1"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.9.1"
 }
 
 @test "auto engine, =8.9.2" {
   cd "${MY_DIR}"
-  write_engine "=8.9.2"
+  write_engines "=8.9.2"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.9.2"
 }
 
 @test "auto engine, =v8.9.3" {
   cd "${MY_DIR}"
-  write_engine "=v8.9.3"
+  write_engines "=v8.9.3"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.9.3"
 }
 
 @test "engine, =v8.9.4" {
   cd "${MY_DIR}"
-  write_engine "=v8.9.4"
+  write_engines "=v8.9.4"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION engine)"
   assert_equal "${output}" "8.9.4"
 }
@@ -74,7 +75,7 @@ function write_engine() {
 @test "auto engine, >1" {
   local TARGET_VERSION="$(display_remote_version latest)"
   cd "${MY_DIR}"
-  write_engine ">1"
+  write_engines ">1"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "${TARGET_VERSION}"
 }
@@ -82,77 +83,77 @@ function write_engine() {
 @test "auto engine, >=2" {
   local TARGET_VERSION="$(display_remote_version latest)"
   cd "${MY_DIR}"
-  write_engine ">=2"
+  write_engines ">=2"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "${TARGET_VERSION}"
 }
 
 @test "auto engine, 8" {
   cd "${MY_DIR}"
-  write_engine "8"
+  write_engines "8"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.17.0"
 }
 
 @test "auto engine, 8.x" {
   cd "${MY_DIR}"
-  write_engine "8.x"
+  write_engines "8.x"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.17.0"
 }
 
 @test "auto engine, 8.X" {
   cd "${MY_DIR}"
-  write_engine "8.X"
+  write_engines "8.X"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.17.0"
 }
 
 @test "auto engine, 8.*" {
   cd "${MY_DIR}"
-  write_engine "8.*"
+  write_engines "8.*"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.17.0"
 }
 
 @test "auto engine, ~8.11.0" {
   cd "${MY_DIR}"
-  write_engine "~8.11.0"
+  write_engines "~8.11.0"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.11.4"
 }
 
 @test "auto engine, ~8.11" {
   cd "${MY_DIR}"
-  write_engine "~8.11"
+  write_engines "~8.11"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.11.4"
 }
 
 @test "auto engine, ~8" {
   cd "${MY_DIR}"
-  write_engine "~8"
+  write_engines "~8"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.17.0"
 }
 
 @test "auto engine, ^8.11.0" {
   cd "${MY_DIR}"
-  write_engine "^8.11.0"
+  write_engines "^8.11.0"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.17.0"
 }
 
 @test "auto engine, ^8.x" {
   cd "${MY_DIR}"
-  write_engine "^8.x"
+  write_engines "^8.x"
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.17.0"
 }
 
 @test "auto engine, subdir" {
   cd "${MY_DIR}"
-  write_engine "8.11.2"
+  write_engines "8.11.2"
   mkdir -p sub-engine
   cd sub-engine
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
@@ -161,7 +162,7 @@ function write_engine() {
 
 @test "auto engine (semver), <8.12" {
   cd "${MY_DIR}"
-  write_engine "<8.12"
+  write_engines "<8.12"
   # newer versions of npx not liking proxy as used in tests
   output="$(https_proxy= n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.11.4"
@@ -169,7 +170,7 @@ function write_engine() {
 
 @test "auto engine (semver), 8.11.1 - 8.11.3" {
   cd "${MY_DIR}"
-  write_engine "8.11.1 - 8.11.3"
+  write_engines "8.11.1 - 8.11.3"
   # newer versions of npx not liking proxy as used in tests
   output="$(https_proxy= n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.11.3"
@@ -177,27 +178,27 @@ function write_engine() {
 
 @test "auto engine (semver), >8.1 <8.12 || >2.1 <3.4" {
   cd "${MY_DIR}"
-  write_engine ">8.1 <8.12 || >2.1 <3.4"
+  write_engines ">8.1 <8.12 || >2.1 <3.4"
   # newer versions of npx not liking proxy as used in tests
   output="$(https_proxy= n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.11.4"
 }
 
-@test "auto (devengines) object, 8.9.0" {
+@test "auto (devEngines) object, 8.9.0" {
   cd "${MY_DIR}"
   echo '{ "devEngines" : { "runtime" : { "name": "node", "version": "8.9.0" } } }' > package.json
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.9.0"
 }
 
-@test "auto (devengines) array, 8.9.0" {
+@test "auto (devEngines) array, 8.9.0" {
   cd "${MY_DIR}"
   echo '{ "devEngines" : { "runtime" : [{ "name": "bun", "version": "1.2.3" }, { "name": "node", "version": "8.9.0" }] } }' > package.json
   output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
   assert_equal "${output}" "8.9.0"
 }
 
-@test "engine (devengines, semver), <8.12" {
+@test "engine (devEngines, semver), <8.12" {
   cd "${MY_DIR}"
   echo '{ "devEngines" : { "runtime" : { "name": "node", "version": "<8.12" } } }' > package.json
   # newer versions of npx not liking proxy as used in tests
@@ -205,13 +206,10 @@ function write_engine() {
   assert_equal "${output}" "8.11.4"
 }
 
-@test "auto mismatch devengines match engines" {
+@test "engine mismatch devEngines match engines" {
   cd "${MY_DIR}"
-  write_engine "8.9.1"
+  write_engines "8.9.1"
   echo '{ "devEngines" : { "runtime" : { "name": "bun", "version": "1.2.3" } } }' >> package.json
-  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION auto)"
+  output="$(n N_TEST_DISPLAY_LATEST_RESOLVED_VERSION engine)"
   assert_equal "${output}" "8.9.1"
 }
-
-# Test ideas
-# devengines wins over engines


### PR DESCRIPTION
## Problem

`devEngines` is the new and more appropriate source for target version of node from `package.json`.

See: #849

## Solution

Expand support for reading `package.json` to include `devEngines`.

Keep the existing pattern with `auto` target of looking for version files (especially `.node-version`) in first pass, before looking for `package.json` in second pass. We rely on other tools for json parsing and range processing, so don't block a directly supported file at the root of a monorepo (say).

Keep using existing target of `engine` which now reads `devEngines.runtime` as well as `engines.node`. 

## ChangeLog

- add support for reading `devEngines.runtime` in `package.json`, with fallback to `engines.node`.